### PR TITLE
feat!: Client#post() always returns array of responses

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -19,6 +19,62 @@
  */
 
 //-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Represents a successful response.
+ */
+export class SuccessResponse {
+	/**
+	 * Indicates success.
+	 * @type {boolean}
+	 * @const
+	 */
+	ok = true;
+
+	/**
+	 * The message posted.
+	 * @type {Object}
+	 */
+	response;
+
+	/**
+	 * Creates a new instance.
+	 * @param {Object} response The response.
+	 */
+	constructor(response) {
+		this.response = response;
+	}
+}
+
+/**
+ * Represents a failure response.
+ */
+export class FailureResponse {
+	/**
+	 * Indicates failure.
+	 * @type {boolean}
+	 * @const
+	 */
+	ok = false;
+
+	/**
+	 * The error or response.
+	 * @type {Object}
+	 */
+	reason;
+
+	/**
+	 * Creates a new instance.
+	 * @param {Object} reason The reason for failure.
+	 */
+	constructor(reason) {
+		this.reason = reason;
+	}
+}
+
+//-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
 
@@ -52,41 +108,19 @@ export class Client {
 	/**
 	 * Posts a message using all strategies.
 	 * @param {string} message The message to post.
-	 * @returns {Promise<Object>} A promise that resolves with an array of results.
+	 * @returns {Promise<Array<SuccessResponse|FailureResponse>>} A promise that resolves with an array of results.
 	 */
 	async post(message) {
-		const results = await Promise.allSettled(
-			this.#strategies.map(strategy => strategy.post(message)),
-		);
-
-		// find any failed results
-		/** @type {Array<number>} */
-		const failedIndices = [];
-		const failed = /** @type {Array<PromiseRejectedResult>} */ (
-			results.filter((result, i) => {
-				if (result.status === "rejected") {
-					failedIndices.push(i);
-					return true;
-				}
-
-				return false;
-			})
-		);
-
-		// if there are failed results, throw an error with the failing strategy names
-		if (failed.length) {
-			throw new AggregateError(
-				failed.map(result => result.reason),
-				`Failed to post to strategies: ${failedIndices.map(i => this.#strategies[i].name).join(", ")}`,
-			);
-		}
-
-		// otherwise return the response payloads keyed by strategy name
-		return Object.fromEntries(
-			results.map((result, i) => [
-				this.#strategies[i].name,
-				/** @type {PromiseFulfilledResult<Object>} */ (result).value,
-			]),
-		);
+		return (
+			await Promise.allSettled(
+				this.#strategies.map(strategy => strategy.post(message)),
+			)
+		).map(result => {
+			if (result.status === "fulfilled") {
+				return new SuccessResponse(result.value);
+			} else {
+				return new FailureResponse(result.reason);
+			}
+		});
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "files": ["src/index.js"],
+  "files": ["src/index.js", "src/bin.js"],
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
This pull request includes several changes to improve the handling of responses and type definitions in the `src/bin.js` and `src/client.js` files, as well as updates to the corresponding tests. 

The `Client#post()` method previously threw an error when an API request failed, meaning  you wouldn't get any info about requests that succeeded. This PR changes the behavior of `Client#post()` so that it always returns an array of responses, similar to `Promise.allSettled()`. This also allows you to register multiple different versions of the same strategy to post to. 

### Improvements to response handling:

* [`src/client.js`](diffhunk://#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0R21-R76): Added `SuccessResponse` and `FailureResponse` classes to represent successful and failed responses, respectively.
* [`src/client.js`](diffhunk://#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0L55-R124): Updated the `post` method in the `Client` class to return an array of `SuccessResponse` or `FailureResponse` objects instead of a mixed object.
* [`src/bin.js`](diffhunk://#diff-1109365b14dbdd8ee303756e665120f3406fe2e8a51c591967e7a3129734e14dL109-R140): Updated the handling of responses to use the new `isSuccessResponse` helper function and log results accordingly.

### Improvements to type definitions:

* [`src/bin.js`](diffhunk://#diff-1109365b14dbdd8ee303756e665120f3406fe2e8a51c591967e7a3129734e14dR20-R50): Added type definitions and updated the `options` object to use a constant type for boolean values.
* [`src/bin.js`](diffhunk://#diff-1109365b14dbdd8ee303756e665120f3406fe2e8a51c591967e7a3129734e14dR92): Added type annotations for the `strategies` array.

### Updates to tests:

* [`tests/client.test.js`](diffhunk://#diff-061ec21c963f5e5a3942435d2a9249c9eba7a779c8732b4af5d176541caee320L65-R71): Updated tests to check for `SuccessResponse` and `FailureResponse` objects instead of mixed objects. [[1]](diffhunk://#diff-061ec21c963f5e5a3942435d2a9249c9eba7a779c8732b4af5d176541caee320L65-R71) [[2]](diffhunk://#diff-061ec21c963f5e5a3942435d2a9249c9eba7a779c8732b4af5d176541caee320R88-R96) [[3]](diffhunk://#diff-061ec21c963f5e5a3942435d2a9249c9eba7a779c8732b4af5d176541caee320R113-R118)