### PR TITLE
fix: Ensure newlines are not escaped in Bluesky messages

### DIFF
--- a/src/util/text-encoding.js
+++ b/src/util/text-encoding.js
@@ -10,8 +10,9 @@
  */
 export function encodeToUnicode(text) {
 	// eslint-disable-next-line no-control-regex
-	return text
-		.replace(/[\ud800-\udbff][\udc00-\udfff]|[^\u0000-\u007f]/g, match => {
+	return text.replace(
+		/[\ud800-\udbff][\udc00-\udfff]|[^\u0000-\u007f]/g,
+		match => {
 			if (match.length === 2) {
 				// This is a surrogate pair
 				const high = match.charCodeAt(0);
@@ -22,6 +23,6 @@ export function encodeToUnicode(text) {
 			// Single unicode character
 			const code = match.charCodeAt(0);
 			return `\\u${code.toString(16).padStart(4, "0")}`;
-		})
-		.replace(/\n/g, "\\n");
+		},
+	);
 }

--- a/tests/util/text-encoding.test.js
+++ b/tests/util/text-encoding.test.js
@@ -34,7 +34,11 @@ describe("text-encoding", () => {
 			{
 				input: "สวัสดีชาวโลก!\nHello World!",
 				expected:
-					"\\u0e2a\\u0e27\\u0e31\\u0e2a\\u0e14\\u0e35\\u0e0a\\u0e32\\u0e27\\u0e42\\u0e25\\u0e01!\\nHello World!",
+					"\\u0e2a\\u0e27\\u0e31\\u0e2a\\u0e14\\u0e35\\u0e0a\\u0e32\\u0e27\\u0e42\\u0e25\\u0e01!\nHello World!",
+			},
+			{
+				input: "Line 1\nLine 2\nLine 3",
+				expected: "Line 1\nLine 2\nLine 3",
 			},
 		];
 
@@ -48,6 +52,11 @@ describe("text-encoding", () => {
 		it("should not modify ASCII characters", () => {
 			const input = "Hello, world! 123";
 			assert.strictEqual(encodeToUnicode(input), input);
+		});
+
+		it("should preserve newlines", () => {
+			const input = "Hello\nWorld\n!";
+			assert.strictEqual(encodeToUnicode(input), "Hello\nWorld\n!");
 		});
 	});
 });


### PR DESCRIPTION
This pull request includes changes to the `src/util/text-encoding.js` file and its corresponding test file to improve the handling and testing of newline characters in the `encodeToUnicode` function. The most important changes include modifying the `encodeToUnicode` function to preserve newlines and updating the tests to ensure this behavior is correctly validated.

Changes to `encodeToUnicode` function:

* [`src/util/text-encoding.js`](diffhunk://#diff-3e8deb40a3d0840462b23442188b1aded5fe914ac0b7088c4cf19320f3e23efcL13-R15): Modified the `encodeToUnicode` function to preserve newline characters by removing the replacement of newlines with `\n`. [[1]](diffhunk://#diff-3e8deb40a3d0840462b23442188b1aded5fe914ac0b7088c4cf19320f3e23efcL13-R15) [[2]](diffhunk://#diff-3e8deb40a3d0840462b23442188b1aded5fe914ac0b7088c4cf19320f3e23efcL25-R27)

Updates to tests:

* [`tests/util/text-encoding.test.js`](diffhunk://#diff-df7600420b38af441ce8cffb7d3a20bb075551c52019e1052f70f634e7829d10L37-R41): Added a new test case to ensure that newline characters are preserved in the output of the `encodeToUnicode` function. [[1]](diffhunk://#diff-df7600420b38af441ce8cffb7d3a20bb075551c52019e1052f70f634e7829d10L37-R41) [[2]](diffhunk://#diff-df7600420b38af441ce8cffb7d3a20bb075551c52019e1052f70f634e7829d10R56-R60)