### PR TITLE
feat: Support image uploads for Discord Webhooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,6 @@ export {
 
 export * from "./strategies/linkedin.js";
 export * from "./strategies/discord.js";
-export * from "./strategies/discord-webhook.js";
+export { DiscordWebhookStrategy } from "./strategies/discord-webhook.js";
 export * from "./strategies/devto.js";
 export { Client, ClientOptions, Strategy } from "./client.js";

--- a/src/strategies/discord-webhook.js
+++ b/src/strategies/discord-webhook.js
@@ -3,7 +3,14 @@
  * @author Nicholas C. Zakas
  */
 
-/* global fetch */
+/* global fetch, FormData, File */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { validatePostOptions } from "../util/options.js";
+import { getImageMimeType } from "../util/images.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -28,6 +35,41 @@
  * @typedef {Object} DiscordWebhookErrorResponse
  * @property {number} code The error code.
  * @property {string} message The error message.
+ */
+
+/** @typedef {import("../types.js").PostOptions} PostOptions */
+
+/**
+ * @typedef {Object} DiscordPayload
+ * @property {string} content The text content of the message
+ * @property {DiscordEmbed[]} [embeds] Array of embedded messages
+ * @property {DiscordMessageReference} [message_reference] Reference to another message
+ * @property {DiscordAttachment[]} [attachments] Array of file attachments
+ */
+
+/**
+ * @typedef {Object} DiscordEmbedImage
+ * @property {string} url URL of the image
+ */
+
+/**
+ * @typedef {Object} DiscordEmbed
+ * @property {string} [title] The title of the embed
+ * @property {string} [description] The description of the embed
+ * @property {DiscordEmbedImage} [thumbnail] The thumbnail image
+ * @property {DiscordEmbedImage} [image] The main image
+ */
+
+/**
+ * @typedef {Object} DiscordMessageReference
+ * @property {string} message_id The ID of the message being referenced
+ */
+
+/**
+ * @typedef {Object} DiscordAttachment
+ * @property {number} id The unique identifier for the attachment
+ * @property {string} description A description of the attachment
+ * @property {string} filename The filename of the attachment
  */
 
 //-----------------------------------------------------------------------------
@@ -69,28 +111,71 @@ export class DiscordWebhookStrategy {
 	/**
 	 * Posts a message to Discord.
 	 * @param {string} message The message to post.
+	 * @param {PostOptions} [postOptions] Additional options for the post.
 	 * @returns {Promise<DiscordWebhookResponse>} A promise that resolves with the message data.
 	 * @throws {Error} When the message fails to post.
 	 */
-	async post(message) {
+	async post(message, postOptions) {
 		if (!message) {
 			throw new TypeError("Missing message to post.");
 		}
+
+		validatePostOptions(postOptions);
 
 		// Tell Discord to wait until the message is posted to return a response
 		const url = new URL(this.#webhookUrl);
 		url.searchParams.set("wait", "true");
 
+		const formData = new FormData();
+
+		/** @type {DiscordPayload} */
+		const payload = {
+			content: message,
+		};
+
+		// Add images if present
+		if (postOptions?.images?.length) {
+			payload.embeds = [];
+			payload.attachments = [];
+
+			/*
+			 * Each image needs to be added in three places:
+			 * 1. As a file field in FormData
+			 * 2. As an embed image in the payload
+			 * 3. As an attachment in the payload
+			 */
+			postOptions.images.forEach((image, index) => {
+				const type = getImageMimeType(image.data);
+				const filename = `image${index + 1}.${type.split("/")[1]}`;
+				const description = image.alt || filename;
+				const file = new File([image.data], filename, { type });
+				formData.append(`files[${index}]`, file);
+
+				payload.attachments?.push({
+					id: index,
+					description,
+					filename,
+				});
+
+				payload.embeds?.push({
+					description,
+					image: {
+						url: `attachment://${filename}`,
+					},
+				});
+			});
+		}
+
+		// Add payload as JSON string
+		formData.append("payload_json", JSON.stringify(payload));
+
 		const response = await fetch(url.href, {
 			method: "POST",
 			headers: {
-				"Content-Type": "application/json",
 				"User-Agent":
 					"Crosspost CLI (https://github.com/humanwhocodes/crosspost, v0.6.3)", // x-release-please-version
 			},
-			body: JSON.stringify({
-				content: message,
-			}),
+			body: formData,
 		});
 
 		if (!response.ok) {

--- a/tests/strategies/discord-webhook.test.js
+++ b/tests/strategies/discord-webhook.test.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/* global FormData */
+
 //-----------------------------------------------------------------------------
 // Imports
 //-----------------------------------------------------------------------------
@@ -72,16 +74,16 @@ describe("DiscordWebhookStrategy", () => {
 
 		it("should successfully post a message", async () => {
 			const message = "Hello Discord!";
+			const payload = {
+				content: message,
+			};
+			const formData = new FormData();
+			formData.append("payload_json", JSON.stringify(payload));
 
 			server.post(
 				{
 					url: "/api/webhooks/123456789/abcdef",
-					headers: {
-						"content-type": "application/json",
-					},
-					body: {
-						content: message,
-					},
+					body: formData,
 				},
 				{
 					status: 200,
@@ -109,6 +111,270 @@ describe("DiscordWebhookStrategy", () => {
 			await assert.rejects(
 				strategy.post("Hello Discord!"),
 				/401 Failed to post message: Unauthorized\nInvalid Webhook Token \(code: 50027\)/,
+			);
+		});
+
+		it("should successfully post a message with images", async () => {
+			const message = "Hello Discord!";
+			const imageData = new Uint8Array([
+				// PNG signature
+				0x89,
+				0x50,
+				0x4e,
+				0x47,
+				0x0d,
+				0x0a,
+				0x1a,
+				0x0a,
+				// IHDR chunk
+				0x00,
+				0x00,
+				0x00,
+				0x0d, // Length
+				0x49,
+				0x48,
+				0x44,
+				0x52, // "IHDR"
+				0x00,
+				0x00,
+				0x00,
+				0x01, // Width: 1
+				0x00,
+				0x00,
+				0x00,
+				0x01, // Height: 1
+				0x08, // Bit depth
+				0x06, // Color type: RGBA
+				0x00, // Compression
+				0x00, // Filter
+				0x00, // Interlace
+				0x1f,
+				0x15,
+				0xc4,
+				0x89, // IHDR CRC
+				// IDAT chunk
+				0x00,
+				0x00,
+				0x00,
+				0x0a, // Length
+				0x49,
+				0x44,
+				0x41,
+				0x54, // "IDAT"
+				0x78,
+				0x9c,
+				0x63,
+				0x00, // zlib header + data
+				0x00,
+				0x00,
+				0x00,
+				0xff, // zlib checksum
+				0xff,
+				0x00,
+				0x02,
+				0x00, // IDAT CRC
+				// IEND chunk
+				0x00,
+				0x00,
+				0x00,
+				0x00, // Length
+				0x49,
+				0x45,
+				0x4e,
+				0x44, // "IEND"
+				0xae,
+				0x42,
+				0x60,
+				0x82, // IEND CRC
+			]);
+			const altText = "Test image";
+			const payload = {
+				content: message,
+				embeds: [
+					{
+						description: altText,
+						image: {
+							url: "attachment://image1.png",
+						},
+					},
+				],
+				attachments: [
+					{
+						id: 0,
+						description: altText,
+						filename: "image1.png",
+					},
+				],
+			};
+			const formData = new FormData();
+			formData.append("payload_json", JSON.stringify(payload));
+			// formData.append("files[0]", new File([imageData], "image1.png", { type: "image/png" }));
+
+			server.post(
+				{
+					url: "/api/webhooks/123456789/abcdef",
+					body: formData,
+				},
+				async request => {
+					const formData = await request.formData();
+					const file = formData.get("files[0]");
+
+					assert.strictEqual(file.type, "image/png");
+					assert.strictEqual(file.name, "image1.png");
+					assert.deepStrictEqual(await file.bytes(), imageData);
+
+					return {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+						},
+						body: MESSAGE_RESPONSE,
+					};
+				},
+			);
+
+			const result = await strategy.post(message, {
+				images: [
+					{
+						data: imageData,
+						alt: altText,
+					},
+				],
+			});
+			assert.deepStrictEqual(result, MESSAGE_RESPONSE);
+		});
+
+		it("should use generic alt text when none is provided", async () => {
+			const message = "Hello Discord!";
+			const imageData = new Uint8Array([
+				// PNG signature
+				0x89,
+				0x50,
+				0x4e,
+				0x47,
+				0x0d,
+				0x0a,
+				0x1a,
+				0x0a,
+				// IHDR chunk
+				0x00,
+				0x00,
+				0x00,
+				0x0d, // Length
+				0x49,
+				0x48,
+				0x44,
+				0x52, // "IHDR"
+				0x00,
+				0x00,
+				0x00,
+				0x01, // Width: 1
+				0x00,
+				0x00,
+				0x00,
+				0x01, // Height: 1
+				0x08, // Bit depth
+				0x06, // Color type: RGBA
+				0x00, // Compression
+				0x00, // Filter
+				0x00, // Interlace
+				0x1f,
+				0x15,
+				0xc4,
+				0x89, // IHDR CRC
+				// IDAT chunk
+				0x00,
+				0x00,
+				0x00,
+				0x0a, // Length
+				0x49,
+				0x44,
+				0x41,
+				0x54, // "IDAT"
+				0x78,
+				0x9c,
+				0x63,
+				0x00, // zlib header + data
+				0x00,
+				0x00,
+				0x00,
+				0xff, // zlib checksum
+				0xff,
+				0x00,
+				0x02,
+				0x00, // IDAT CRC
+				// IEND chunk
+				0x00,
+				0x00,
+				0x00,
+				0x00, // Length
+				0x49,
+				0x45,
+				0x4e,
+				0x44, // "IEND"
+				0xae,
+				0x42,
+				0x60,
+				0x82, // IEND CRC
+			]);
+			const payload = {
+				content: message,
+				embeds: [
+					{
+						description: "image1.png",
+						image: {
+							url: "attachment://image1.png",
+						},
+					},
+				],
+				attachments: [
+					{
+						id: 0,
+						description: "image1.png",
+						filename: "image1.png",
+					},
+				],
+			};
+			const formData = new FormData();
+			formData.append("payload_json", JSON.stringify(payload));
+
+			server.post(
+				{
+					url: "/api/webhooks/123456789/abcdef",
+					body: formData,
+				},
+				async request => {
+					const formData = await request.formData();
+					const file = formData.get("files[0]");
+
+					assert.strictEqual(file.type, "image/png");
+					assert.strictEqual(file.name, "image1.png");
+					assert.deepStrictEqual(await file.bytes(), imageData);
+
+					return {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+						},
+						body: MESSAGE_RESPONSE,
+					};
+				},
+			);
+
+			const result = await strategy.post(message, {
+				images: [
+					{
+						data: imageData,
+					},
+				],
+			});
+			assert.deepStrictEqual(result, MESSAGE_RESPONSE);
+		});
+
+		it("should throw error for invalid post options", async () => {
+			await assert.rejects(
+				strategy.post("Hello", { images: [{ invalid: true }] }),
+				/Image must have data/,
 			);
 		});
 	});


### PR DESCRIPTION
This pull request introduces significant enhancements to the `DiscordWebhookStrategy` in the `src/strategies/discord-webhook.js` file, including support for image attachments and improved validation for post options. It also updates the corresponding test suite to ensure the new functionality is thoroughly tested.

### Enhancements to `DiscordWebhookStrategy`:

* **Support for Image Attachments**:
  - Added new type definitions for `DiscordPayload`, `DiscordEmbed`, `DiscordAttachment`, and related types to support image attachments in messages.
  - Modified the `post` method to accept an additional `postOptions` parameter, allowing users to include images in their messages.

* **Validation and Utility Functions**:
  - Imported and utilized `validatePostOptions` and `getImageMimeType` utility functions to validate post options and determine image MIME types. [[1]](diffhunk://#diff-054592df3d75c72ab9a4bf88c4e08dea2d253cb83d72601c7b7f5cd9183e63dcL6-R13) [[2]](diffhunk://#diff-054592df3d75c72ab9a4bf88c4e08dea2d253cb83d72601c7b7f5cd9183e63dcR114-R178)

### Updates to Tests:

* **New Test Cases**:
  - Added test cases to verify the successful posting of messages with and without images, and to ensure proper handling of image data and validation errors.
  
* **Form Data Handling**:
  - Updated existing tests to use `FormData` instead of JSON payloads to align with the new implementation.

### Export Changes:

* **Named Export for `DiscordWebhookStrategy`**:
  - Changed the export statement for `DiscordWebhookStrategy` to a named export to improve modularity and clarity.