### PR TITLE
feat: Support image uploads for Discord bots

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {
 } from "./strategies/twitter.js";
 
 export * from "./strategies/linkedin.js";
-export * from "./strategies/discord.js";
+export { DiscordStrategy } from "./strategies/discord.js";
 export { DiscordWebhookStrategy } from "./strategies/discord-webhook.js";
 export * from "./strategies/devto.js";
 export { Client, ClientOptions, Strategy } from "./client.js";


### PR DESCRIPTION
This pull request includes significant improvements to the `DiscordStrategy` class in the `src/strategies/discord.js` file, along with corresponding updates to the tests. The changes enhance the functionality for posting messages with images and improve the overall structure and maintainability of the code.

Enhancements to `DiscordStrategy`:

* Modified the `post` method in `DiscordStrategy` to support additional post options, including images. The method now validates post options and constructs a `FormData` object for the payload.
* Added several new type definitions (`DiscordPayload`, `DiscordEmbedImage`, `DiscordEmbed`, `DiscordAttachment`) to support the new functionality and improve type safety.

Code structure improvements:

* Added imports for `validatePostOptions` and `getImageMimeType` utilities to the `discord.js` file.
* Updated the export statement in `src/index.ts` to export `DiscordStrategy` explicitly instead of using a wildcard export.

Test updates:

* Enhanced the tests in `tests/strategies/discord.test.js` to cover the new functionality, including posting messages with images and handling different scenarios such as missing alt text and invalid post options. [[1]](diffhunk://#diff-0acbd03b4b201bfdec8b817f811fcf8b389cc18fb348274329a2432c7835a74cR99-R112) [[2]](diffhunk://#diff-0acbd03b4b201bfdec8b817f811fcf8b389cc18fb348274329a2432c7835a74cR142-R274)
* Added a mock PNG image data array to the test file to facilitate testing of image uploads.