### PR TITLE
feat: Allow specifying path to .env file in CROSSPOST_DOTENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Each strategy requires a set of environment variables in order to execute:
 - dev.to
     - `DEVTO_API_KEY`
 
-Tip: You can also load environment variables from a `.env` file in the current working directory by setting the environment variable `CROSSPOST_DOTENV` to `1`.
+Tip: You can load environment variables from a `.env` file by setting the environment variable `CROSSPOST_DOTENV`. Set it to `1` to use `.env` in the current working directory, or set it to a specific filepath to use a different location.
 
 ### MCP Server
 


### PR DESCRIPTION
In some situations, it's helpful to specify the exact location of a `.env` file instead of assuming there's one in the current working directory. This PR allows the `CROSSPOST_DOTENV` environment variable to optionally contain a file path to use instead of `.env` in the current working directory.