### PR TITLE
feat: Add id and display name to strategies

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -29,16 +29,6 @@ const postSchema = {
 	message: z.string(),
 };
 
-const properNames = new Map([
-	["twitter", "X (formerly Twitter)"],
-	["linkedin", "LinkedIn"],
-	["mastodon", "Mastodon"],
-	["discord", "Discord"],
-	["discord-webhook", "Discord Webhook"],
-	["bluesky", "Bluesky"],
-	["devto", "Dev.to"],
-]);
-
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
@@ -98,7 +88,7 @@ export class CrosspostMcpServer extends McpServer {
 		// prompt to post to a specific strategy
 		for (const strategy of this.#strategies) {
 			this.prompt(
-				`post-to-${strategy.name}`,
+				`post-to-${strategy.id}`,
 				postSchema,
 				({ message }) => ({
 					messages: [
@@ -106,7 +96,7 @@ export class CrosspostMcpServer extends McpServer {
 							role: "user",
 							content: {
 								type: "text",
-								text: `Post this message to ${properNames.get(strategy.name) || strategy.name}: ${message}`,
+								text: `Post this message to ${strategy.name}: ${message}`,
 							},
 						},
 					],
@@ -136,8 +126,8 @@ export class CrosspostMcpServer extends McpServer {
 		// tools to post to specific strategies
 		for (const strategy of this.#strategies) {
 			this.tool(
-				`post-to-${strategy.name}`,
-				`Post to ${properNames.get(strategy.name)}`,
+				`post-to-${strategy.id}`,
+				`Post to ${strategy.name}`,
 				postSchema,
 				async ({ message }) => {
 					const results = await strategy.post(message);

--- a/src/strategies/bluesky.js
+++ b/src/strategies/bluesky.js
@@ -270,11 +270,18 @@ async function postMessage(options, session, message, postOptions) {
  */
 export class BlueskyStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "bluesky";
+	id = "bluesky";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Bluesky";
 
 	/**
 	 * Options for this instance.

--- a/src/strategies/devto.js
+++ b/src/strategies/devto.js
@@ -105,11 +105,18 @@ async function postArticle(apiKey, content, postOptions) {
  */
 export class DevtoStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "devto";
+	id = "devto";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Dev.to";
 
 	/**
 	 * The API key for Dev.to.

--- a/src/strategies/discord-webhook.js
+++ b/src/strategies/discord-webhook.js
@@ -81,11 +81,18 @@ import { getImageMimeType } from "../util/images.js";
  */
 export class DiscordWebhookStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "discord-webhook";
+	id = "discord-webhook";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Discord Webhook";
 
 	/**
 	 * The webhook URL for this instance.

--- a/src/strategies/discord.js
+++ b/src/strategies/discord.js
@@ -77,11 +77,18 @@ const API_BASE = "https://discord.com/api/v10";
  */
 export class DiscordStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "discord";
+	id = "discord";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Discord Bot";
 
 	/**
 	 * Options for this instance.

--- a/src/strategies/linkedin.js
+++ b/src/strategies/linkedin.js
@@ -303,11 +303,18 @@ async function createPost(options, personUrn, message, postOptions) {
  */
 export class LinkedInStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "linkedin";
+	id = "linkedin";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "LinkedIn";
 
 	/**
 	 * Options for this instance.

--- a/src/strategies/mastodon.js
+++ b/src/strategies/mastodon.js
@@ -135,11 +135,18 @@ async function uploadMedia({ accessToken, host }, image, signal) {
  */
 export class MastodonStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "mastodon";
+	id = "mastodon";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Mastodon";
 
 	/**
 	 * Options for this instance.

--- a/src/strategies/twitter.js
+++ b/src/strategies/twitter.js
@@ -37,11 +37,18 @@ import { getImageMimeType } from "../util/images.js";
  */
 export class TwitterStrategy {
 	/**
-	 * The name of the strategy.
+	 * The ID of the strategy.
 	 * @type {string}
 	 * @readonly
 	 */
-	name = "twitter";
+	id = "twitter";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "X (formerly Twitter)";
 
 	/**
 	 * Options for this instance.

--- a/src/types.js
+++ b/src/types.js
@@ -25,6 +25,7 @@
 
 /**
  * @typedef {Object} Strategy
- * @property {string} name The name of the strategy.
+ * @property {string} name The display name of the strategy.
+ * @property {string} id A unique ID for the strategy.
  * @property {(message: string, options?: PostOptions) => Promise<any>} post A function that posts a message.
  */

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -22,14 +22,18 @@ import {
 //-----------------------------------------------------------------------------
 
 class MockTwitterStrategy {
-	name = "twitter";
+	id = "twitter";
+	name = "Twitter";
+
 	async post(message) {
 		return { message: `${message} (from Twitter)` };
 	}
 }
 
 class MockMastodonStrategy {
-	name = "mastodon";
+	id = "mastodon";
+	name = "Mastodon";
+
 	async post(message) {
 		if (message === "fail") {
 			return { ok: false, error: "Failed to post" };

--- a/tests/strategies/bluesky.test.js
+++ b/tests/strategies/bluesky.test.js
@@ -114,9 +114,10 @@ describe("BlueskyStrategy", function () {
 			);
 		});
 
-		it("should create an instance if all options are provided", function () {
+		it("should create an instance with correct id and name", () => {
 			const strategy = new BlueskyStrategy(options);
-			assert.strictEqual(strategy.name, "bluesky");
+			assert.strictEqual(strategy.id, "bluesky");
+			assert.strictEqual(strategy.name, "Bluesky");
 		});
 	});
 

--- a/tests/strategies/devto.test.js
+++ b/tests/strategies/devto.test.js
@@ -57,9 +57,10 @@ describe("DevtoStrategy", () => {
 			);
 		});
 
-		it("should create an instance if all options are provided", () => {
+		it("should create an instance with correct id and name", () => {
 			const strategy = new DevtoStrategy(options);
-			assert.strictEqual(strategy.name, "devto");
+			assert.strictEqual(strategy.id, "devto");
+			assert.strictEqual(strategy.name, "Dev.to");
 		});
 	});
 

--- a/tests/strategies/discord-webhook.test.js
+++ b/tests/strategies/discord-webhook.test.js
@@ -113,11 +113,12 @@ describe("DiscordWebhookStrategy", () => {
 			);
 		});
 
-		it("should create an instance if webhook URL is provided", () => {
+		it("should create an instance with correct id and name", () => {
 			const strategy = new DiscordWebhookStrategy({
 				webhookUrl: WEBHOOK_URL,
 			});
-			assert.strictEqual(strategy.name, "discord-webhook");
+			assert.strictEqual(strategy.id, "discord-webhook");
+			assert.strictEqual(strategy.name, "Discord Webhook");
 		});
 	});
 

--- a/tests/strategies/discord.test.js
+++ b/tests/strategies/discord.test.js
@@ -61,12 +61,13 @@ describe("DiscordStrategy", () => {
 			);
 		});
 
-		it("should create an instance if all options are provided", () => {
+		it("should create an instance with correct id and name", () => {
 			const strategy = new DiscordStrategy({
 				botToken: BOT_TOKEN,
 				channelId: CHANNEL_ID,
 			});
-			assert.strictEqual(strategy.name, "discord");
+			assert.strictEqual(strategy.id, "discord");
+			assert.strictEqual(strategy.name, "Discord Bot");
 		});
 	});
 

--- a/tests/strategies/linkedin.test.js
+++ b/tests/strategies/linkedin.test.js
@@ -57,11 +57,12 @@ describe("LinkedInStrategy", () => {
 			);
 		});
 
-		it("should create an instance if all required options are provided", () => {
+		it("should create an instance with correct id and name", () => {
 			const strategy = new LinkedInStrategy({
 				accessToken: ACCESS_TOKEN,
 			});
-			assert.strictEqual(strategy.name, "linkedin");
+			assert.strictEqual(strategy.id, "linkedin");
+			assert.strictEqual(strategy.name, "LinkedIn");
 		});
 	});
 

--- a/tests/strategies/mastodon.test.js
+++ b/tests/strategies/mastodon.test.js
@@ -49,6 +49,13 @@ describe("MastodonStrategy", () => {
 			const instance = new MastodonStrategy(options);
 			assert(instance instanceof MastodonStrategy);
 		});
+
+		it("should create an instance with correct id and name", () => {
+			const options = { accessToken: "token", host: "mastodon.social" };
+			const instance = new MastodonStrategy(options);
+			assert.strictEqual(instance.id, "mastodon");
+			assert.strictEqual(instance.name, "Mastodon");
+		});
 	});
 
 	describe("post", () => {

--- a/tests/strategies/twitter.test.js
+++ b/tests/strategies/twitter.test.js
@@ -68,6 +68,17 @@ describe("TwitterStrategy", () => {
 				});
 			}, /consumer secret/i);
 		});
+
+		it("should create an instance with correct id and name", () => {
+			const strategy = new TwitterStrategy({
+				accessTokenKey: "foo",
+				accessTokenSecret: "bar",
+				apiConsumerKey: "baz",
+				apiConsumerSecret: "qux",
+			});
+			assert.strictEqual(strategy.id, "twitter");
+			assert.strictEqual(strategy.name, "X (formerly Twitter)");
+		});
 	});
 
 	// this test fails in Bun for some reason -- investigate later


### PR DESCRIPTION
This updates the `Strategy` interface to have both an `id` and a `name`. The `id` is used as an identifier throughout while `name` is a human-friendly display name useful for displaying in UIs.