### PR TITLE
feat: Claude compatibility for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Each strategy requires a set of environment variables in order to execute:
 
 Tip: You can load environment variables from a `.env` file by setting the environment variable `CROSSPOST_DOTENV`. Set it to `1` to use `.env` in the current working directory, or set it to a specific filepath to use a different location.
 
-### MCP Server
+### MCP Server Usage
 
 Crosspost can be run as an MCP (Model Context Protocol) server, which allows it to be used by AI agents:
 
@@ -182,6 +182,62 @@ To run the MCP server through the [MCP Inspector](https://github.com/modelcontex
 ```shell
 npx run mcp:inspect -- -t -m -b
 ```
+
+#### Using the MCP Server with Claude Desktop
+
+To use the MCP server with Claude you must have [Node.js](https://nodejs.org) installed and then run:
+
+```shell
+npm install -g @humanwhocodes/crosspost
+```
+
+Then, in Claude Desktop:
+
+1. Click on File -> Settings.
+1. Select "Developer".
+1. Click "Edit Config".
+
+Claude will then create a `claude_desktop_config.json` file. Open it and add the following:
+
+```json
+{
+	"mcpServers": {
+		"crosspost": {
+			"command": "crosspost",
+			"args": ["-m", "-l", "--mcp"],
+			"env": {
+				"LINKEDIN_ACCESS_TOKEN": "abcdefghijklmnop",
+				"MASTODON_ACCESS_TOKEN": "abcdefghijklmnop",
+				"MASTODON_HOST": "mastodon.social"
+			}
+		}
+	}
+}
+```
+
+This example enables Mastodon and LinkedIn so the `env` key contains the environment variables necessary to post to those services. You can customize the services by passing different command line arguments as you would using the CLI.
+
+If you'd prefer not to put your environment variables directly into the JSON file, you can create a [`.env` file](https://www.npmjs.com/package/dotenv) and use the `CROSSPOST_DOTENV` environment variable to point to it:
+
+```json
+{
+	"mcpServers": {
+		"crosspost": {
+			"command": "crosspost",
+			"args": ["-m", "-l", "--mcp"],
+			"env": {
+				"CROSSPOST_DOTENV": "/usr/nzakas/settings/.env"
+			}
+		}
+	}
+}
+```
+
+Here are some prompts you can try:
+
+- "Crosspost this message: Hello world!" (posts to all available services)
+- "Post this to Twitter: Hello X!" (posts just to Twitter)
+- "Post this to Mastodon and Bluesky: Hello friends!" (posts to Mastodon and Bluesky)
 
 ## Setting up Strategies
 

--- a/src/bin.js
+++ b/src/bin.js
@@ -202,7 +202,7 @@ const postOptions = {};
 if (flags.mcp) {
 	const server = new CrosspostMcpServer({ strategies });
 	await server.connect(new StdioServerTransport());
-	console.log(
+	console.error(
 		"MCP server started. You can now send messages to it via stdin.",
 	);
 } else {

--- a/tests/bin.test.js
+++ b/tests/bin.test.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Tests for the bin file.
+ * @author Nicholas C. Zakas
+ */
+
+/* global clearTimeout */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { strict as assert } from "node:assert";
+import { fork } from "node:child_process";
+import path from "node:path";
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+const executablePath = path.resolve("src/bin.js");
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("bin", function () {
+	it("should not print anything to stdout", done => {
+		const child = fork(executablePath, ["--mcp", "-l"], {
+			env: {
+				LINKEDIN_ACCESS_TOKEN: "foo",
+			},
+			stdio: "pipe",
+		});
+
+		const tid = setTimeout(() => {
+			child.kill();
+		}, 500);
+
+		let failed;
+
+		// check if anything comes out on stdout and fail if so
+		child.stdout.on("data", data => {
+			clearTimeout(tid);
+			failed = data;
+			child.kill();
+		});
+
+		child.on("exit", () => {
+			clearTimeout(tid);
+
+			if (failed) {
+				assert.fail(`stdout was not empty:${failed}`);
+			}
+
+			done();
+		});
+	});
+});


### PR DESCRIPTION
This pull request includes updates to the `README.md` file, a bug fix in `src/bin.js`, and new tests in `tests/bin.test.js`. The most important changes are detailed below:

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R170): Updated the section title from "MCP Server" to "MCP Server Usage" for clarity.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R186-R241): Added detailed instructions for using the MCP server with Claude Desktop, including configuration examples and prompts.

Bug fix:

* [`src/bin.js`](diffhunk://#diff-1109365b14dbdd8ee303756e665120f3406fe2e8a51c591967e7a3129734e14dL205-R205): Changed a console output from `console.log` to `console.error` to correctly report MCP server startup messages.

Testing enhancements:

* [`tests/bin.test.js`](diffhunk://#diff-d3b5b86bbb589dc885dab8c40943e3f527c7d371ed94ca21c8e14fe3bb970151R1-R58): Added a new test file to ensure the MCP server does not print anything to stdout when started.