### PR TITLE
fix: Telegram chat ID must be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ const discordWebhook = new DiscordWebhookStrategy({
 	webhookUrl: "your-webhook-url",
 });
 
-// Note: Bot token required, chat ID optional
+// Note: Bot token and chat ID required
 const telegram = new TelegramStrategy({
 	botToken: "your-bot-token",
-	chatId: "your-chat-id", // Optional if the bot can determine the chat ID automatically
+	chatId: "your-chat-id",
 });
 
 // Note: API key required
@@ -191,7 +191,7 @@ Each strategy requires a set of environment variables in order to execute:
     - `DEVTO_API_KEY`
 - Telegram
     - `TELEGRAM_BOT_TOKEN`
-    - `TELEGRAM_CHAT_ID` (optional, if not provided will use the first chat that has messaged the bot)
+    - `TELEGRAM_CHAT_ID`
 
 Tip: You can load environment variables from a `.env` file by setting the environment variable `CROSSPOST_DOTENV`. Set it to `1` to use `.env` in the current working directory, or set it to a specific filepath to use a different location.
 
@@ -402,14 +402,7 @@ To enable posting to Telegram using a bot:
 4. BotFather will provide you with a token, which will look something like `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
 5. Copy this token and use it as the value for the `TELEGRAM_BOT_TOKEN` environment variable.
 
-For the `TELEGRAM_CHAT_ID`, you have two options:
-
-**Option 1:** Let the bot determine the chat ID automatically
-
-- Start a conversation with your bot by sending a message to it.
-- When posting, the bot will automatically find the first available chat ID from your conversation history.
-
-**Option 2:** Specify a chat ID manually
+For the `TELEGRAM_CHAT_ID` (required):
 
 - You can specify any Telegram username such as `@username`.
 - To get your own chat ID, you can message [@userinfobot](https://t.me/userinfobot) on Telegram.

--- a/jsr.json
+++ b/jsr.json
@@ -7,8 +7,7 @@
       "jsr.json",
       "LICENSE",
       "README.md",
-      "dist/index.js",
-      "dist/index.d.ts"
+      "dist"
     ]
   }
 }

--- a/src/bin.js
+++ b/src/bin.js
@@ -199,7 +199,7 @@ if (flags.telegram) {
 	strategies.push(
 		new TelegramStrategy({
 			botToken: env.require("TELEGRAM_BOT_TOKEN"),
-			chatId: env.get("TELEGRAM_CHAT_ID"),
+			chatId: env.require("TELEGRAM_CHAT_ID"),
 		}),
 	);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@
  * @fileoverview Main entry point for the project.
  * @author Nicholas C. Zakas
  */
+
+/* @ts-self-types="./index.d.ts" */
+
 export * from "./types.js";
 export {
 	BlueskyStrategy,


### PR DESCRIPTION
This pull request includes several changes to the Telegram integration, primarily focusing on making the `chatId` a required parameter and removing the logic for automatically determining the chat ID. The changes affect the documentation, source code, and tests.

### Documentation Updates:
* Updated `README.md` to reflect that `chatId` is now a required parameter for the Telegram strategy. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R194) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L405-R405)

### Source Code Changes:
* Modified `TelegramStrategy` to require `chatId` and removed the logic for automatically determining the chat ID. [[1]](diffhunk://#diff-ca035fb773692dd1d1e3638dd7ec609b10f28380c6bed37cb05c4761ffea797bL24-R24) [[2]](diffhunk://#diff-ca035fb773692dd1d1e3638dd7ec609b10f28380c6bed37cb05c4761ffea797bL105-R115) [[3]](diffhunk://#diff-ca035fb773692dd1d1e3638dd7ec609b10f28380c6bed37cb05c4761ffea797bL259-R218)
* Updated `src/bin.js` to require `TELEGRAM_CHAT_ID` environment variable.

### Test Updates:
* Removed tests related to automatically determining the chat ID and added a test to ensure an error is thrown if `chatId` is missing. [[1]](diffhunk://#diff-1d6db226701caaccb4c47bae133a327b6ada46aadae663f7a731416bba60ee09L32-L48) [[2]](diffhunk://#diff-1d6db226701caaccb4c47bae133a327b6ada46aadae663f7a731416bba60ee09R60-R67) [[3]](diffhunk://#diff-1d6db226701caaccb4c47bae133a327b6ada46aadae663f7a731416bba60ee09L161-L196) [[4]](diffhunk://#diff-1d6db226701caaccb4c47bae133a327b6ada46aadae663f7a731416bba60ee09L276-L318)