### PR TITLE
feat: Detect hashtags in Bluesky messages

### DIFF
--- a/tests/util/bluesky-facets.test.js
+++ b/tests/util/bluesky-facets.test.js
@@ -9,7 +9,11 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import { detectFacets } from "../../src/util/bluesky-facets.js";
+import {
+	detectFacets,
+	BLUESKY_URL_FACET,
+	BLUESKY_TAG_FACET,
+} from "../../src/util/bluesky-facets.js";
 import assert from "node:assert";
 
 //-----------------------------------------------------------------------------
@@ -52,67 +56,165 @@ function normalizeProtocol(uri) {
 //------------------------------------------------------------------------------
 
 describe("detectFacets()", () => {
-	[
-		"https://example.com",
-		"https://example.co.uk/path",
-		"http://test.org/path",
-		"https://subdomain.example.net/path/to/resource",
-		"http://example.com?query=string",
-		"https://example.com#hash",
-		"https://example.com/path?query=string#hash",
-		"example.com/no-protocol",
-		"test.org/path/no-protocol",
-	].forEach(uri => {
-		it("should detect a URL all alone", () => {
-			const text = `${uri}`;
-			const result = detectFacets(text)[0];
-			assert.deepEqual(result.features, [
-				{
-					$type: "app.bsky.richtext.facet#link",
-					uri: normalizeProtocol(uri),
-				},
-			]);
+	describe("URL detection", () => {
+		[
+			"https://example.com",
+			"https://example.co.uk/path",
+			"http://test.org/path",
+			"https://subdomain.example.net/path/to/resource",
+			"http://example.com?query=string",
+			"https://example.com#hash",
+			"https://example.com/path?query=string#hash",
+			"example.com/no-protocol",
+			"test.org/path/no-protocol",
+		].forEach(uri => {
+			it("should detect a URL all alone", () => {
+				const text = `${uri}`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_URL_FACET,
+						uri: normalizeProtocol(uri),
+					},
+				]);
 
-			assertByteLocation(text, result, uri);
+				assertByteLocation(text, result, uri);
+			});
+
+			it("should detect a URL at the start of a string", () => {
+				const text = `${uri} is a test.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_URL_FACET,
+						uri: normalizeProtocol(uri),
+					},
+				]);
+
+				assertByteLocation(text, result, uri);
+			});
+
+			it("should detect a URL in the middle of a string", () => {
+				const text = `This is a test ${uri}, of a URL.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_URL_FACET,
+						uri: normalizeProtocol(uri),
+					},
+				]);
+
+				assertByteLocation(text, result, uri);
+			});
+
+			it("should detect a URL at the end of a string", () => {
+				const text = `This is a test of a URL ${uri}.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_URL_FACET,
+						uri: normalizeProtocol(uri),
+					},
+				]);
+
+				assertByteLocation(text, result, uri);
+			});
+		});
+	});
+
+	describe("Hashtag detection", () => {
+		[
+			"javascript",
+			"coding123",
+			"crosspost",
+			"bluesky",
+			"react-native",
+			"web_development",
+		].forEach(tag => {
+			it("should detect a hashtag all alone", () => {
+				const text = `#${tag}`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_TAG_FACET,
+						tag,
+					},
+				]);
+
+				assertByteLocation(text, result, `#${tag}`);
+			});
+
+			it("should detect a hashtag at the start of a string", () => {
+				const text = `#${tag} is a test.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_TAG_FACET,
+						tag,
+					},
+				]);
+
+				assertByteLocation(text, result, `#${tag}`);
+			});
+
+			it("should detect a hashtag in the middle of a string", () => {
+				const text = `This is a test #${tag}, of a hashtag.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_TAG_FACET,
+						tag,
+					},
+				]);
+
+				assertByteLocation(text, result, `#${tag}`);
+			});
+
+			it("should detect a hashtag at the end of a string", () => {
+				const text = `This is a test of a hashtag #${tag}.`;
+				const result = detectFacets(text)[0];
+				assert.deepEqual(result.features, [
+					{
+						$type: BLUESKY_TAG_FACET,
+						tag,
+					},
+				]);
+
+				assertByteLocation(text, result, `#${tag}`);
+			});
 		});
 
-		it("should detect a URL at the start of a string", () => {
-			const text = `${uri} is a test.`;
-			const result = detectFacets(text)[0];
-			assert.deepEqual(result.features, [
+		it("should detect both URLs and hashtags in the same text", () => {
+			const text =
+				"Check out https://example.com for #javascript resources!";
+			const results = detectFacets(text);
+
+			// Should have two facets
+			assert.strictEqual(results.length, 2);
+
+			// URL facet
+			assert.deepEqual(results[0].features, [
 				{
-					$type: "app.bsky.richtext.facet#link",
-					uri: normalizeProtocol(uri),
+					$type: BLUESKY_URL_FACET,
+					uri: "https://example.com",
 				},
 			]);
+			assertByteLocation(text, results[0], "https://example.com");
 
-			assertByteLocation(text, result, uri);
+			// Hashtag facet
+			assert.deepEqual(results[1].features, [
+				{
+					$type: BLUESKY_TAG_FACET,
+					tag: "javascript",
+				},
+			]);
+			assertByteLocation(text, results[1], "#javascript");
 		});
 
-		it("should detect a URL in the middle of a string", () => {
-			const text = `This is a test ${uri}, of a URL.`;
-			const result = detectFacets(text)[0];
-			assert.deepEqual(result.features, [
-				{
-					$type: "app.bsky.richtext.facet#link",
-					uri: normalizeProtocol(uri),
-				},
-			]);
-
-			assertByteLocation(text, result, uri);
-		});
-
-		it("should detect a URL at the end of a string", () => {
-			const text = `This is a test of a URL ${uri}.`;
-			const result = detectFacets(text)[0];
-			assert.deepEqual(result.features, [
-				{
-					$type: "app.bsky.richtext.facet#link",
-					uri: normalizeProtocol(uri),
-				},
-			]);
-
-			assertByteLocation(text, result, uri);
+		it("should not detect invalid hashtags", () => {
+			const text = "#123 #. ## # #!";
+			const results = detectFacets(text);
+			assert.strictEqual(results.length, 0);
 		});
 	});
 });


### PR DESCRIPTION
Previously, Crosspost only identified URLs in Bluesky messages. This adds the ability to detect hashtags, too, so they will be linked as expected when posted.

### Feature Enhancements:

* Added a new constant `BLUESKY_TAG_FACET` to represent the hashtag facet type. (`src/util/bluesky-facets.js`, [src/util/bluesky-facets.jsR19](diffhunk://#diff-5310ad1d39b5cc52526187fda7e2970611d7dc728b2955572edfd1581efa4b3dR19))
* Introduced a new class `BlueSkyTagFacetFeature` to handle hashtag facets, including its type and tag property. (`src/util/bluesky-facets.js`, [src/util/bluesky-facets.jsR111-R136](diffhunk://#diff-5310ad1d39b5cc52526187fda7e2970611d7dc728b2955572edfd1581efa4b3dR111-R136))
* Created a `detectTags` function to identify hashtags in text, strip trailing punctuation, and calculate their byte ranges. (`src/util/bluesky-facets.js`, [src/util/bluesky-facets.jsR213-R256](diffhunk://#diff-5310ad1d39b5cc52526187fda7e2970611d7dc728b2955572edfd1581efa4b3dR213-R256))
* Updated the `detectFacets` function to include detected hashtags as facets alongside URLs. (`src/util/bluesky-facets.js`, [src/util/bluesky-facets.jsR268-R271](diffhunk://#diff-5310ad1d39b5cc52526187fda7e2970611d7dc728b2955572edfd1581efa4b3dR268-R271))

### Test Suite Updates:

* Expanded the test suite to include hashtag detection, verifying various scenarios such as hashtags alone, at the start, middle, or end of a string, and mixed with URLs. (`tests/util/bluesky-facets.test.js`, [tests/util/bluesky-facets.test.jsR124-R220](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768R124-R220))
* Ensured invalid hashtags (e.g., numeric-only or malformed hashtags) are not detected. (`tests/util/bluesky-facets.test.js`, [tests/util/bluesky-facets.test.jsR124-R220](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768R124-R220))
* Updated existing tests to use the new `BLUESKY_URL_FACET` constant for consistency. (`tests/util/bluesky-facets.test.js`, [[1]](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768L71-R76) [[2]](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768L84-R89) [[3]](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768L97-R102) [[4]](diffhunk://#diff-871f3e9ddf7032bdb57f4fe03644317a9c9eed5e01c11cbcb34dbdd046de7768L110-R115)