### PR TITLE
chore(deps): Upgrade Mentoss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^9.0.0",
         "lint-staged": "15.4.3",
-        "mentoss": "^0.5.1",
+        "mentoss": "^0.9.2",
         "mocha": "^11.0.0",
         "nock": "^13.5.5",
         "prettier": "^3.3.3",
@@ -2928,9 +2928,9 @@
       }
     },
     "node_modules/mentoss": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mentoss/-/mentoss-0.5.1.tgz",
-      "integrity": "sha512-A4k5r7suUbUMU0Tlsq5tx3fNqGtwUoUQGQ4qeM7QLrv5+/IeIAkPWX4a78JjEZPEdK2fBKoB4hJbJvHicxyggw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/mentoss/-/mentoss-0.9.2.tgz",
+      "integrity": "sha512-pxDUmI70bAAb596F4c3btBqHyTOw3bIGJcHaViNUB9EG4yIzgCdvCO2Qkmji4YHBGAsFtStsWML6nGwnooWUDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9.0.0",
     "lint-staged": "15.4.3",
-    "mentoss": "^0.5.1",
+    "mentoss": "^0.9.2",
     "mocha": "^11.0.0",
     "nock": "^13.5.5",
     "prettier": "^3.3.3",

--- a/tests/strategies/devto.test.js
+++ b/tests/strategies/devto.test.js
@@ -15,7 +15,7 @@ import { MockServer, FetchMocker } from "mentoss";
 // Data
 //-----------------------------------------------------------------------------
 
-const API_URL = "https://dev.to/api";
+const API_URL = "https://dev.to";
 const API_KEY = "abc123";
 
 const CREATE_ARTICLE_RESPONSE = {


### PR DESCRIPTION
This pull request updates the `mentoss` library to a newer version and adjusts the `API_URL` constant in the `devto` test file to reflect a simplified base URL.

Library update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L85-R85): Updated the `mentoss` dependency from version `^0.5.1` to `^0.9.2`.

Test adjustment:

* [`tests/strategies/devto.test.js`](diffhunk://#diff-d0b241d56a8fb2d153959ec577c8d3fbb1f724cc8adc53015167b321c7461dd1L18-R18): Modified the `API_URL` constant to use a simplified base URL (`https://dev.to` instead of `https://dev.to/api`).