### PR TITLE
refactor: SLACK_BOT_TOKEN -> SLACK_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Each strategy requires a set of environment variables in order to execute:
     - `TELEGRAM_BOT_TOKEN`
     - `TELEGRAM_CHAT_ID`
 - Slack
-    - `SLACK_BOT_TOKEN`
+    - `SLACK_TOKEN`
     - `SLACK_CHANNEL`
 
 Tip: You can load environment variables from a `.env` file by setting the environment variable `CROSSPOST_DOTENV`. Set it to `1` to use `.env` in the current working directory, or set it to a specific filepath to use a different location.
@@ -458,11 +458,11 @@ To enable posting to Slack using a bot:
 3. Click "Create App".
 4. In the left sidebar, click "OAuth & Permissions".
 5. Scroll down to "Scopes" and under "Bot Token Scopes", add the following scopes:
-   - `chat:write` - Send messages as the bot user
-   - `files:write` - Upload files as the bot user (required for image support)
+    - `chat:write` - Send messages as the bot user
+    - `files:write` - Upload files as the bot user (required for image support)
 6. Scroll to the top and click "Install to Workspace".
 7. Review the permissions and click "Allow".
-8. Copy the "Bot User OAuth Token" that starts with `xoxb-`. This is your `SLACK_BOT_TOKEN`.
+8. Copy the "Bot User OAuth Token" that starts with `xoxb-`. This is your `SLACK_TOKEN`.
 
 To get your channel ID:
 
@@ -471,7 +471,7 @@ To get your channel ID:
 3. The channel ID is the part after the last slash in the URL (e.g., `C1234567890`).
 4. Alternatively, you can use the channel name (e.g., `#general`).
 
-Use the bot token as the `SLACK_BOT_TOKEN` environment variable and the channel ID or name as the `SLACK_CHANNEL` environment variable.
+Use the bot token as the `SLACK_TOKEN` environment variable and the channel ID or name as the `SLACK_CHANNEL` environment variable.
 
 **Note:** The bot must be added to the channel you want to post to. You can do this by mentioning the bot in the channel (e.g., `@your-bot-name`) or by using the `/invite @your-bot-name` command.
 

--- a/src/bin.js
+++ b/src/bin.js
@@ -211,7 +211,7 @@ if (flags.telegram) {
 if (flags.slack) {
 	strategies.push(
 		new SlackStrategy({
-			botToken: env.require("SLACK_BOT_TOKEN"),
+			botToken: env.require("SLACK_TOKEN"),
 			channel: env.require("SLACK_CHANNEL"),
 		}),
 	);


### PR DESCRIPTION
This pull request updates the Slack integration to use a new environment variable name, `SLACK_TOKEN`, instead of `SLACK_BOT_TOKEN`. The changes are reflected in both the documentation and the codebase.

### Documentation Updates:
* Updated `README.md` to rename the environment variable `SLACK_BOT_TOKEN` to `SLACK_TOKEN` in the instructions for setting up Slack integration. This includes references in the environment variable list, token copying instructions, and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-R233) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L465-R465) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L474-R474)

### Code Updates:
* Modified `src/bin.js` to replace the usage of `SLACK_BOT_TOKEN` with `SLACK_TOKEN` in the `SlackStrategy` configuration.