### PR TITLE
feat: Add -v/--version flags to CLI

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -70,12 +70,20 @@ const options = {
 	image: { type: stringType },
 	"image-alt": { type: stringType },
 	help: { type: booleanType, short: "h" },
+	version: { type: booleanType, short: "v" },
 };
 
 const { values: flags, positionals } = parseArgs({
 	options,
 	allowPositionals: true,
 });
+
+if (flags.version) {
+	const packagePath = new URL("../package.json", import.meta.url);
+	const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+	console.log(packageJson.version);
+	process.exit(0);
+}
 
 if (flags.mcp && flags.file) {
 	console.error("Error: --file cannot be used with --mcp");
@@ -111,6 +119,7 @@ if (
 	console.log("--image		The image file to upload with the message.");
 	console.log("--image-alt	Alt text for the image (default: filename).");
 	console.log("--help, -h	Show this message.");
+	console.log("--version, -v	Show version number.");
 	process.exit(1);
 }
 

--- a/tests/bin.test.js
+++ b/tests/bin.test.js
@@ -11,6 +11,7 @@
 
 import { strict as assert } from "node:assert";
 import { fork } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 //-----------------------------------------------------------------------------
@@ -18,6 +19,7 @@ import path from "node:path";
 //-----------------------------------------------------------------------------
 
 const executablePath = path.resolve("src/bin.js");
+const builtExecutablePath = path.resolve("dist/bin.js");
 
 //-----------------------------------------------------------------------------
 // Tests
@@ -53,6 +55,67 @@ describe("bin", function () {
 			}
 
 			done();
+		});
+	});
+
+	describe("version flag", function () {
+		it("should display version with --version flag", done => {
+			const child = fork(builtExecutablePath, ["--version"], {
+				stdio: "pipe",
+			});
+
+			let output = "";
+
+			child.stdout.on("data", data => {
+				output += data.toString();
+			});
+
+			child.on("exit", code => {
+				assert.strictEqual(code, 0);
+				assert.match(output.trim(), /^\d+\.\d+\.\d+$/);
+				done();
+			});
+		});
+
+		it("should display version with -v flag", done => {
+			const child = fork(builtExecutablePath, ["-v"], {
+				stdio: "pipe",
+			});
+
+			let output = "";
+
+			child.stdout.on("data", data => {
+				output += data.toString();
+			});
+
+			child.on("exit", code => {
+				assert.strictEqual(code, 0);
+				assert.match(output.trim(), /^\d+\.\d+\.\d+$/);
+				done();
+			});
+		});
+
+		it("should display correct version from package.json", done => {
+			// Read the actual version from package.json
+			const packagePath = path.resolve("package.json");
+			const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+			const expectedVersion = packageJson.version;
+
+			const child = fork(builtExecutablePath, ["--version"], {
+				stdio: "pipe",
+			});
+
+			let output = "";
+
+			child.stdout.on("data", data => {
+				output += data.toString();
+			});
+
+			child.on("exit", code => {
+				assert.strictEqual(code, 0);
+				assert.strictEqual(output.trim(), expectedVersion);
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION
This pull request adds support for displaying the CLI tool's version via a new `--version`/`-v` flag and introduces corresponding automated tests to ensure correct functionality. The changes improve usability by allowing users to easily check the installed version and strengthen reliability with thorough test coverage.

**New CLI flag and functionality:**

* Added a `--version`/`-v` flag to the CLI options in `src/bin.js`, which outputs the version from `package.json` and exits when invoked.
* Updated the help message to document the new `--version`/`-v` flag.

**Testing enhancements:**

* Added a new test suite in `tests/bin.test.js` to verify that the CLI correctly displays the version for both `--version` and `-v` flags, and that the output matches the version in `package.json`.
* Imported `fs` and defined `builtExecutablePath` in `tests/bin.test.js` to support the new tests.