### PR TITLE
feat: Add OrgSocialStrategy for Org Social network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The API is split into two parts:
     - `TelegramStrategy`
     - `DevtoStrategy`
     - `NostrStrategy` (requires Node.js v22+)
+    - `OrgSocialStrategy`
 
 Each strategy requires its own parameters that are specific to the service. If you only want to post to a particular service, you can just directly use the strategy for that service.
 
@@ -46,6 +47,7 @@ import {
 	TelegramStrategy,
 	DevtoStrategy,
 	NostrStrategy,
+	OrgSocialStrategy,
 } from "@humanwhocodes/crosspost";
 
 // Note: Use an app password, not your login password!
@@ -102,6 +104,13 @@ const nostr = new NostrStrategy({
 	relays: ["wss://relay.example.com", "wss://relay2.example.com"],
 });
 
+// Note: vfile and public URL required (from Org Social Host signup)
+const orgSocial = new OrgSocialStrategy({
+	vfile: "http://host.org-social.org/vfile?token=YOUR_TOKEN&ts=TIMESTAMP&sig=SIGNATURE",
+	publicUrl: "http://host.org-social.org/your-nick/social.org",
+	host: "host.org-social.org", // optional, defaults to "host.org-social.org"
+});
+
 // create a client that will post to all services
 const client = new Client({
 	strategies: [
@@ -114,6 +123,7 @@ const client = new Client({
 		telegram,
 		devto,
 		nostr,
+		orgSocial,
 	],
 });
 
@@ -185,6 +195,7 @@ Usage: crosspost [options] ["Message to post."]
 --telegram      Post to Telegram.
 --slack, -s     Post to Slack.
 --nostr, -n     Post to Nostr.
+--orgsocial, -o Post to Org Social.
 --mcp           Start MCP server.
 --file          The file to read the message from.
 --image         The image file to upload with the message.
@@ -247,6 +258,10 @@ Each strategy requires a set of environment variables in order to execute:
 - Nostr
     - `NOSTR_PRIVATE_KEY`
     - `NOSTR_RELAYS`
+- Org Social
+    - `ORGSOCIAL_VFILE`
+    - `ORGSOCIAL_PUBLIC_URL`
+    - `ORGSOCIAL_HOST` (optional)
 
 Tip: You can load environment variables from a `.env` file by setting the environment variable `CROSSPOST_DOTENV`. Set it to `1` to use `.env` in the current working directory, or set it to a specific filepath to use a different location.
 
@@ -506,6 +521,66 @@ Nostr posts are "short text notes" (kind 1 events) with a 280 character limit. I
 **Important:** Nostr support only works in Node.js v22+.
 
 **Security:** Keep your private key secure and never share it. Consider using a dedicated key for crossposting rather than your main Nostr identity key.
+
+### Org Social
+
+To enable posting to Org Social:
+
+Org Social is a decentralized social network that runs on Org Mode files over HTTP. To use it with Crosspost, you need to sign up at an Org Social Host instance.
+
+1. Sign up at an Org Social Host instance (e.g., [host.org-social.org](https://host.org-social.org/)):
+
+    ```bash
+    curl -X POST https://host.org-social.org/signup \
+      -H "Content-Type: application/json" \
+      -d '{"nick": "your-nickname"}'
+    ```
+
+2. You'll receive two important values:
+
+    - **`vfile`**: A virtual file URL with authentication (format: `http://host.org-social.org/vfile?token=...&ts=...&sig=...`)
+    - **`public-url`**: Your public social.org file URL (format: `http://host.org-social.org/your-nick/social.org`)
+
+3. Use these values with the `OrgSocialStrategy`:
+    ```js
+    const orgSocial = new OrgSocialStrategy({
+    	vfile: "YOUR_VFILE_URL",
+    	publicUrl: "YOUR_PUBLIC_URL",
+    	host: "host.org-social.org", // optional
+    });
+    ```
+
+For the `ORGSOCIAL_VFILE` (required):
+
+- The virtual file URL you received during signup
+- Contains authentication tokens to update your social.org file
+- Keep this URL secure and never share it
+
+For the `ORGSOCIAL_PUBLIC_URL` (required):
+
+- Your public social.org file URL that others can access
+- This is what you share with followers
+
+For the `ORGSOCIAL_HOST` (optional):
+
+- The Org Social Host instance domain
+- Defaults to `host.org-social.org` if not provided
+
+**Important Notes:**
+
+- Images are not supported in Org Social text posts. Include image links in the message text instead.
+- Org Social has no character limit - you can write posts of any length.
+- Org Social files use Org Mode format with rich text features like bold, italic, code blocks, tables, and more.
+- Posts are appended at the end of your social.org file, after the last post.
+- The first post after `* Posts` has no blank line before it, but subsequent posts have one blank line separator.
+- Each post gets a unique RFC 3339 timestamp ID. If posting multiple times quickly, the strategy waits to ensure unique IDs.
+- If you don't update your social.org at least once a month on the default host, you may lose your nickname.
+
+**Learn more:**
+
+- [Org Social Specification](https://github.com/tanrax/org-social)
+- [Org Social Host Documentation](https://github.com/tanrax/org-social-host)
+- [Org Social Community](https://org-social.org/social.org)
 
 ## License
 

--- a/examples/orgsocial-example.js
+++ b/examples/orgsocial-example.js
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Example usage of OrgSocialStrategy
+ * @author Andros Fenollosa
+ */
+
+/* global setTimeout, AbortController */
+
+import { OrgSocialStrategy, Client } from "@humanwhocodes/crosspost";
+
+// Initialize the Org Social strategy with your vfile and public URL
+// You get these from signing up at an Org Social Host instance
+const orgSocial = new OrgSocialStrategy({
+	// The vfile URL you received during signup (contains authentication token)
+	vfile: "http://host.org-social.org/vfile?token=YOUR_TOKEN&ts=TIMESTAMP&sig=SIGNATURE",
+
+	// Your public social.org URL
+	publicUrl: "http://host.org-social.org/your-nick/social.org",
+
+	// Optional: Custom Org Social Host instance (defaults to "host.org-social.org")
+	host: "host.org-social.org",
+});
+
+// Example 1: Post a simple message
+export async function postSimpleMessage() {
+	try {
+		const response = await orgSocial.post("Hello from Org Social! 🌍");
+		console.log("Post successful!");
+		console.log("Public URL:", response.data["public-url"]);
+	} catch (error) {
+		console.error("Failed to post:", error.message);
+	}
+}
+
+// Example 2: Post with multiple lines
+export async function postMultilineMessage() {
+	try {
+		const message = `This is a multiline post with rich content.
+
+I can include:
+- Lists with multiple items
+- *Bold text* and /italic text/
+- Code snippets: ~print("hello")~
+- Links: [[https://example.com][Example website]]
+
+And much more!`;
+
+		const response = await orgSocial.post(message);
+		console.log("Multiline post successful!");
+		console.log("Public URL:", response.data["public-url"]);
+	} catch (error) {
+		console.error("Failed to post:", error.message);
+	}
+}
+
+// Example 3: Use with the Client to post to multiple services
+export async function postToMultipleServices() {
+	// You can combine Org Social with other strategies
+	const client = new Client({
+		strategies: [
+			orgSocial,
+			// Add other strategies here (Twitter, Mastodon, etc.)
+		],
+	});
+
+	try {
+		const results = await client.post("Hello from all my social networks!");
+
+		results.forEach(result => {
+			if (result.ok) {
+				console.log(
+					`✓ ${result.name}: ${result.url || "Posted successfully"}`,
+				);
+			} else {
+				console.error(`✗ ${result.name}: ${result.reason.message}`);
+			}
+		});
+	} catch (error) {
+		console.error("Failed to post:", error.message);
+	}
+}
+
+// Example 4: Handle abort signals
+export async function postWithAbortSignal() {
+	const controller = new AbortController();
+
+	// Cancel the post after 5 seconds
+	setTimeout(() => controller.abort(), 5000);
+
+	try {
+		await orgSocial.post("This post might be cancelled...", {
+			signal: controller.signal,
+		});
+		console.log("Post successful!");
+	} catch (error) {
+		if (error.name === "AbortError") {
+			console.log("Post was cancelled");
+		} else {
+			console.error("Failed to post:", error.message);
+		}
+	}
+}
+
+// Note: Images are not supported in Org Social text posts
+// If you need to share images, include links to them in your message:
+export async function postWithImageLinks() {
+	try {
+		const message = `Check out this beautiful sunset!
+
+[[https://example.com/sunset.jpg][Beautiful Sunset]]`;
+
+		await orgSocial.post(message);
+		console.log("Post with image link successful!");
+	} catch (error) {
+		console.error("Failed to post:", error.message);
+	}
+}
+
+// Important notes about Org Social:
+// - Posts are appended at the END of your social.org file, after the last post
+// - No character limit - write as much as you want!
+// - Supports full Org Mode syntax: bold, italic, code blocks, tables, etc.
+// - Images not supported directly, but you can include image links
+
+// Run examples
+// Uncomment the function you want to test:
+// postSimpleMessage();
+// postMultilineMessage();
+// postToMultipleServices();
+// postWithAbortSignal();
+// postWithImageLinks();

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,7 +820,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1806,7 +1805,6 @@
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2155,7 +2153,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3106,7 +3103,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4458,7 +4454,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4986,7 +4981,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,4 +65,11 @@ export {
 	NostrEvent,
 	NostrEventResponse,
 } from "./strategies/nostr.js";
+export {
+	OrgSocialStrategy,
+	OrgSocialOptions,
+	OrgSocialErrorResponse,
+	OrgSocialSuccessResponse,
+	OrgSocialPost,
+} from "./strategies/orgsocial.js";
 export { Client, ClientOptions, Strategy } from "./client.js";

--- a/src/strategies/orgsocial.js
+++ b/src/strategies/orgsocial.js
@@ -1,0 +1,374 @@
+/**
+ * @fileoverview Org Social strategy for posting messages.
+ * @author Andros Fenollosa
+ */
+
+/* global fetch, FormData, Blob, setTimeout */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { validatePostOptions } from "../util/options.js";
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("../types.js").PostOptions} PostOptions */
+
+/**
+ * @typedef {Object} OrgSocialOptions
+ * @property {string} vfile The virtual file URL with authentication token.
+ * @property {string} publicUrl The public URL of the social.org file.
+ * @property {string} [host="host.org-social.org"] The Org Social Host instance (defaults to official host).
+ */
+
+/**
+ * @typedef {Object} OrgSocialErrorResponse
+ * @property {string} type The response type (e.g., "Error").
+ * @property {Array<string>} errors Array of error messages.
+ */
+
+/**
+ * @typedef {Object} OrgSocialResponseData
+ * @property {string} message Success message.
+ * @property {string} public-url The public URL of the social.org file.
+ */
+
+/**
+ * @typedef {Object} OrgSocialSuccessResponse
+ * @property {string} type The response type (e.g., "Success").
+ * @property {Array<string>} errors Empty array for successful requests.
+ * @property {OrgSocialResponseData} data Response data.
+ */
+
+/**
+ * @typedef {Object} OrgSocialPost
+ * @property {string} id The RFC 3339 timestamp ID of the post.
+ * @property {string} content The content of the post.
+ * @property {Record<string, string>} [properties] Additional properties for the post.
+ */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Formats a date to RFC 3339 format with timezone offset.
+ * @param {Date} date The date to format.
+ * @returns {string} The formatted date string (e.g., "2025-01-26T12:00:00+0100").
+ */
+function formatRFC3339(date) {
+	/**
+	 * Pads a number with leading zeros.
+	 * @param {number} num The number to pad.
+	 * @returns {string} The padded string.
+	 */
+	const pad = num => String(num).padStart(2, "0");
+
+	const year = date.getFullYear();
+	const month = pad(date.getMonth() + 1);
+	const day = pad(date.getDate());
+	const hours = pad(date.getHours());
+	const minutes = pad(date.getMinutes());
+	const seconds = pad(date.getSeconds());
+
+	// Get timezone offset in format +HHMM or -HHMM
+	const tzOffset = -date.getTimezoneOffset();
+	const tzSign = tzOffset >= 0 ? "+" : "-";
+	const tzHours = pad(Math.floor(Math.abs(tzOffset) / 60));
+	const tzMinutes = pad(Math.abs(tzOffset) % 60);
+
+	return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${tzSign}${tzHours}${tzMinutes}`;
+}
+
+/**
+ * Downloads the current social.org file from the host.
+ * @param {string} publicUrl The public URL of the social.org file.
+ * @param {AbortSignal} [signal] The abort signal for the request.
+ * @returns {Promise<string>} A promise that resolves with the file content.
+ */
+async function downloadSocialFile(publicUrl, signal) {
+	const response = await fetch(publicUrl, {
+		method: "GET",
+		signal,
+	});
+
+	if (response.ok) {
+		return response.text();
+	}
+
+	// If file doesn't exist yet (404), return a minimal template
+	if (response.status === 404) {
+		return `#+TITLE: My Org Social
+#+NICK: user
+
+* Posts
+`;
+	}
+
+	try {
+		const errorBody = /** @type {OrgSocialErrorResponse} */ (
+			await response.json()
+		);
+		throw new Error(
+			`${response.status} ${response.statusText}: Failed to download social.org:\n${errorBody.errors.join(", ")}`,
+		);
+	} catch {
+		throw new Error(
+			`${response.status} ${response.statusText}: Failed to download social.org`,
+		);
+	}
+}
+
+/**
+ * Creates a new post entry in Org Mode format.
+ * @param {OrgSocialPost} post The post data.
+ * @returns {string} The formatted post entry.
+ */
+function createPostEntry(post) {
+	let entry = "**\n";
+	entry += ":PROPERTIES:\n";
+	entry += `:ID: ${post.id}\n`;
+
+	// Add any additional properties
+	if (post.properties) {
+		for (const [key, value] of Object.entries(post.properties)) {
+			entry += `:${key.toUpperCase()}: ${value}\n`;
+		}
+	}
+
+	entry += ":END:\n";
+	entry += `${post.content}\n`;
+
+	return entry;
+}
+
+/**
+ * Inserts a new post into the social.org file content.
+ * Posts are added at the end of the file, after the last post.
+ * First post has no blank line before it, subsequent posts have one blank line.
+ * @param {string} content The current file content.
+ * @param {OrgSocialPost} post The post to insert.
+ * @returns {string} The updated file content.
+ */
+function insertPost(content, post) {
+	const postEntry = createPostEntry(post);
+
+	// Find the "* Posts" section
+	const postsRegex = /^(\* Posts)$/m;
+	const match = content.match(postsRegex);
+
+	if (match && match.index !== undefined) {
+		// Get everything after "* Posts"
+		const afterPosts = content.substring(match.index + match[0].length);
+
+		// Remove ONLY empty ** at the very beginning (template marker)
+		// Match: newline + "**" + optional whitespace + end of string (no more content)
+		// Real posts will have \n**\n:PROPERTIES: so they won't match
+		const cleanAfterPosts = afterPosts.replace(/^\n\*\*\s*$/, "");
+
+		// Check if there are already posts with content
+		const hasExistingPosts = /\*\*\s*\n:PROPERTIES:/m.test(cleanAfterPosts);
+
+		// Reconstruct content
+		const beforePosts = content.substring(0, match.index + match[0].length);
+
+		if (hasExistingPosts) {
+			// Already has posts, add blank line before new post
+			return beforePosts + cleanAfterPosts + "\n" + postEntry;
+		} else {
+			// First post, no blank line
+			return beforePosts + "\n" + postEntry;
+		}
+	}
+
+	// If "* Posts" doesn't exist, add it at the end with the post (no blank line)
+	return content + "\n* Posts\n" + postEntry;
+}
+
+/**
+ * Uploads the updated social.org file to the host.
+ * @param {OrgSocialOptions} options The strategy options.
+ * @param {string} content The file content to upload.
+ * @param {AbortSignal} [signal] The abort signal for the request.
+ * @returns {Promise<OrgSocialSuccessResponse>} A promise that resolves with the upload response.
+ */
+async function uploadSocialFile(options, content, signal) {
+	const uploadUrl = `https://${options.host}/upload`;
+
+	const formData = new FormData();
+	formData.append("vfile", options.vfile);
+	formData.append(
+		"file",
+		new Blob([content], { type: "text/plain; charset=utf-8" }),
+		"social.org",
+	);
+
+	const response = await fetch(uploadUrl, {
+		method: "POST",
+		body: formData,
+		signal,
+	});
+
+	if (response.ok) {
+		return /** @type {Promise<OrgSocialSuccessResponse>} */ (
+			response.json()
+		);
+	}
+
+	try {
+		const errorBody = /** @type {OrgSocialErrorResponse} */ (
+			await response.json()
+		);
+		throw new Error(
+			`${response.status} ${response.statusText}: Failed to upload social.org:\n${errorBody.errors.join(", ")}`,
+		);
+	} catch {
+		throw new Error(
+			`${response.status} ${response.statusText}: Failed to upload social.org`,
+		);
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * A strategy for posting messages to Org Social.
+ */
+export class OrgSocialStrategy {
+	/**
+	 * Maximum length of an Org Social post in characters.
+	 * Org Social has no character limit.
+	 * @type {number}
+	 * @const
+	 */
+	MAX_MESSAGE_LENGTH = Infinity;
+
+	/**
+	 * The ID of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	id = "orgsocial";
+
+	/**
+	 * The display name of the strategy.
+	 * @type {string}
+	 * @readonly
+	 */
+	name = "Org Social";
+
+	/**
+	 * Options for this instance.
+	 * @type {OrgSocialOptions}
+	 */
+	#options;
+
+	/**
+	 * Creates a new instance.
+	 * @param {OrgSocialOptions} options Options for the instance.
+	 * @throws {Error} When options are missing.
+	 */
+	constructor(options) {
+		const { vfile, publicUrl } = options;
+
+		if (!vfile) {
+			throw new TypeError("Missing vfile.");
+		}
+
+		if (!publicUrl) {
+			throw new TypeError("Missing publicUrl.");
+		}
+
+		// Set default host if not provided
+		this.#options = {
+			host: "host.org-social.org",
+			...options,
+		};
+	}
+
+	/**
+	 * Calculates the length of a message according to Org Social's algorithm.
+	 * Org Social counts all Unicode characters as-is.
+	 * @param {string} message The message to calculate the length of.
+	 * @returns {number} The calculated length of the message.
+	 */
+	calculateMessageLength(message) {
+		return [...message].length;
+	}
+
+	/**
+	 * Posts a message to Org Social.
+	 * @param {string} message The message to post.
+	 * @param {PostOptions} [postOptions] Additional options for the post.
+	 * @returns {Promise<OrgSocialSuccessResponse>} A promise that resolves with the upload response.
+	 */
+	async post(message, postOptions) {
+		if (!message) {
+			throw new TypeError("Missing message to post.");
+		}
+
+		validatePostOptions(postOptions);
+
+		// Images are not supported in Org Social text posts
+		if (postOptions?.images?.length) {
+			throw new Error(
+				"Images are not supported in Org Social posts. Consider adding image links in the message text.",
+			);
+		}
+
+		// 1. Download current social.org file from public URL
+		const currentContent = await downloadSocialFile(
+			this.#options.publicUrl,
+			postOptions?.signal,
+		);
+
+		// 2. Create new post with current timestamp
+		// Add milliseconds to ensure unique IDs when posting multiple times quickly
+		const now = new Date();
+		let postId = formatRFC3339(now);
+
+		// Check if this ID already exists in the content
+		// If it does, wait 1 second and generate a new one
+		while (currentContent.includes(`:ID: ${postId}`)) {
+			await new Promise(resolve => setTimeout(resolve, 1000));
+			postId = formatRFC3339(new Date());
+		}
+
+		const post = {
+			id: postId,
+			content: message,
+		};
+
+		// 3. Insert post into content
+		const updatedContent = insertPost(currentContent, post);
+
+		// 4. Upload updated content
+		return uploadSocialFile(
+			this.#options,
+			updatedContent,
+			postOptions?.signal,
+		);
+	}
+
+	/**
+	 * Extracts a URL from an Org Social Host API response.
+	 * @param {OrgSocialSuccessResponse} response The response from the upload request.
+	 * @returns {string} The URL for the Org Social post.
+	 */
+	getUrlFromResponse(response) {
+		const publicUrl = response?.data?.["public-url"];
+		if (!publicUrl) {
+			throw new Error("Public URL not found in response");
+		}
+
+		// The public-url points to the social.org file
+		// We return it as-is since Org Social doesn't have individual post URLs
+		// Clients would need to fetch the file and find the post by ID
+		return publicUrl;
+	}
+}

--- a/tests/strategies/orgsocial-insert.test.js
+++ b/tests/strategies/orgsocial-insert.test.js
@@ -1,0 +1,227 @@
+/**
+ * @fileoverview Tests for insertPost function logic in OrgSocialStrategy
+ * @author Andros Fenollosa
+ */
+
+import assert from "node:assert";
+
+/**
+ * Simplified version of insertPost function for testing
+ * @param {string} content The current file content.
+ * @param {string} postEntry The post entry to insert.
+ * @returns {string} The updated file content.
+ */
+function insertPost(content, postEntry) {
+	// Find the "* Posts" section
+	const postsRegex = /^(\* Posts)$/m;
+	const match = content.match(postsRegex);
+
+	if (match && match.index !== undefined) {
+		// Get everything after "* Posts"
+		const afterPosts = content.substring(match.index + match[0].length);
+
+		// Remove ONLY empty ** at the very beginning (template marker)
+		const cleanAfterPosts = afterPosts.replace(/^\n\*\*\s*$/, "");
+
+		// Check if there are already posts with content
+		const hasExistingPosts = /\*\*\s*\n:PROPERTIES:/m.test(cleanAfterPosts);
+
+		// Reconstruct content
+		const beforePosts = content.substring(0, match.index + match[0].length);
+
+		if (hasExistingPosts) {
+			// Already has posts, add blank line before new post
+			return beforePosts + cleanAfterPosts + "\n" + postEntry;
+		} else {
+			// First post, no blank line
+			return beforePosts + "\n" + postEntry;
+		}
+	}
+
+	// If "* Posts" doesn't exist, add it at the end with the post (no blank line)
+	return content + "\n* Posts\n" + postEntry;
+}
+
+describe("insertPost function", () => {
+	it("should append post at the end when Posts section exists", () => {
+		const existingContent = `#+TITLE: Test User
+#+NICK: testuser
+
+* Posts
+**
+:PROPERTIES:
+:ID: 2025-01-01T12:00:00+0100
+:END:
+First post content
+`;
+
+		const newPost = `**
+:PROPERTIES:
+:ID: 2025-01-02T14:30:00+0100
+:END:
+Second post content
+`;
+
+		const result = insertPost(existingContent, newPost);
+
+		// Verify both posts are present
+		assert.ok(
+			result.includes("First post content"),
+			"Should contain first post",
+		);
+		assert.ok(
+			result.includes("Second post content"),
+			"Should contain second post",
+		);
+
+		// Verify order: first post should come before second post
+		const firstPostIndex = result.indexOf("First post content");
+		const secondPostIndex = result.indexOf("Second post content");
+		assert.ok(
+			firstPostIndex < secondPostIndex,
+			"Second post should be after first post",
+		);
+
+		// Verify the new post is at the end of the file
+		const trimmedResult = result.trim();
+		assert.ok(
+			trimmedResult.endsWith("Second post content"),
+			"New post should be at the end",
+		);
+	});
+
+	it("should create Posts section and add post when section doesn't exist", () => {
+		const existingContent = `#+TITLE: Test User
+#+NICK: testuser
+`;
+
+		const newPost = `**
+:PROPERTIES:
+:ID: 2025-01-01T12:00:00+0100
+:END:
+First post content
+`;
+
+		const result = insertPost(existingContent, newPost);
+
+		// Verify Posts section was created
+		assert.ok(result.includes("* Posts"), "Should create Posts section");
+
+		// Verify post was added
+		assert.ok(
+			result.includes("First post content"),
+			"Should contain the post",
+		);
+
+		// Verify order: Posts section comes before the post
+		const postsIndex = result.indexOf("* Posts");
+		const postIndex = result.indexOf("First post content");
+		assert.ok(
+			postsIndex < postIndex,
+			"Post should come after Posts section",
+		);
+
+		// Verify no blank line between "* Posts" and first "**"
+		assert.ok(
+			result.includes("* Posts\n**"),
+			"Should have no blank line between Posts and first post",
+		);
+	});
+
+	it("should remove empty post markers from template", () => {
+		const templateContent = `#+TITLE: Test User
+#+NICK: testuser
+
+* Posts
+**
+`;
+
+		const newPost = `**
+:PROPERTIES:
+:ID: 2025-01-01T12:00:00+0100
+:END:
+First real post
+`;
+
+		const result = insertPost(templateContent, newPost);
+
+		// Verify the empty ** was removed
+		const postsMatch = result.match(/\* Posts\n\*\*/g);
+		assert.strictEqual(
+			postsMatch ? postsMatch.length : 0,
+			1,
+			"Should only have one ** marker (the real post)",
+		);
+
+		// Verify the post content is there
+		assert.ok(
+			result.includes("First real post"),
+			"Should contain the post",
+		);
+
+		// Verify correct format: * Posts\n**\n:PROPERTIES:
+		assert.ok(
+			result.includes("* Posts\n**\n:PROPERTIES:"),
+			"Should have correct format without empty post",
+		);
+	});
+
+	it("should append multiple posts in order with correct spacing", () => {
+		let content = `#+TITLE: Test User
+#+NICK: testuser
+
+* Posts
+`;
+
+		const post1 = `**
+:PROPERTIES:
+:ID: 2025-01-01T12:00:00+0100
+:END:
+Post 1
+`;
+
+		const post2 = `**
+:PROPERTIES:
+:ID: 2025-01-02T12:00:00+0100
+:END:
+Post 2
+`;
+
+		const post3 = `**
+:PROPERTIES:
+:ID: 2025-01-03T12:00:00+0100
+:END:
+Post 3
+`;
+
+		// Add posts one by one
+		content = insertPost(content, post1);
+		content = insertPost(content, post2);
+		content = insertPost(content, post3);
+
+		// Verify all posts are present
+		assert.ok(content.includes("Post 1"), "Should contain post 1");
+		assert.ok(content.includes("Post 2"), "Should contain post 2");
+		assert.ok(content.includes("Post 3"), "Should contain post 3");
+
+		// Verify order
+		const post1Index = content.indexOf("Post 1");
+		const post2Index = content.indexOf("Post 2");
+		const post3Index = content.indexOf("Post 3");
+
+		assert.ok(post1Index < post2Index, "Post 2 should be after Post 1");
+		assert.ok(post2Index < post3Index, "Post 3 should be after Post 2");
+
+		// Verify first post has no blank line before it
+		assert.ok(
+			content.includes("* Posts\n**"),
+			"First post should have no blank line before it",
+		);
+
+		// Verify subsequent posts have blank line before them
+		assert.ok(
+			content.includes("Post 1\n\n**"),
+			"Second post should have blank line before it",
+		);
+	});
+});

--- a/tests/strategies/orgsocial.test.js
+++ b/tests/strategies/orgsocial.test.js
@@ -1,0 +1,456 @@
+/**
+ * @fileoverview Tests for the OrgSocialStrategy class.
+ * @author Andros Fenollosa
+ */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { OrgSocialStrategy } from "../../src/strategies/orgsocial.js";
+import assert from "node:assert";
+import { FetchMocker, MockServer } from "mentoss";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const SAMPLE_SOCIAL_ORG = `#+TITLE: Test User
+#+NICK: testuser
+
+* Posts
+`;
+
+const SAMPLE_VFILE = "http://localhost/vfile?token=test&ts=123&sig=abc";
+const SAMPLE_PUBLIC_URL = "http://localhost/testuser/social.org";
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("OrgSocialStrategy", () => {
+	describe("constructor", () => {
+		it("should throw an error if vfile is missing", () => {
+			assert.throws(
+				() => new OrgSocialStrategy({ publicUrl: SAMPLE_PUBLIC_URL }),
+				TypeError,
+				"Missing vfile.",
+			);
+		});
+
+		it("should throw an error if publicUrl is missing", () => {
+			assert.throws(
+				() => new OrgSocialStrategy({ vfile: SAMPLE_VFILE }),
+				TypeError,
+				"Missing publicUrl.",
+			);
+		});
+
+		it("should create an instance if both vfile and publicUrl are provided", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			assert(instance instanceof OrgSocialStrategy);
+		});
+
+		it("should create an instance with correct id and name", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			assert.strictEqual(instance.id, "orgsocial");
+			assert.strictEqual(instance.name, "Org Social");
+		});
+
+		it("should use default host if not provided", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			assert.ok(instance);
+		});
+
+		it("should use custom host if provided", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+				host: "custom.host.org",
+			};
+			const instance = new OrgSocialStrategy(options);
+			assert.ok(instance);
+		});
+	});
+
+	describe("calculateMessageLength", () => {
+		it("should calculate message length correctly for ASCII text", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello, Org Social!";
+			// "Hello, Org Social!" = 18 characters
+			assert.strictEqual(instance.calculateMessageLength(message), 18);
+		});
+
+		it("should calculate message length correctly for Unicode text", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello 世界! 🌍";
+			assert.strictEqual(instance.calculateMessageLength(message), 11);
+		});
+
+		it("should calculate message length correctly for emojis", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "🚀🌟✨";
+			assert.strictEqual(instance.calculateMessageLength(message), 3);
+		});
+	});
+
+	describe("post", () => {
+		const server = new MockServer("https://host.org-social.org");
+		const publicServer = new MockServer("http://localhost");
+		const fetchMocker = new FetchMocker({
+			servers: [server, publicServer],
+		});
+
+		beforeEach(() => {
+			fetchMocker.mockGlobal(fetchMocker.fetch);
+		});
+
+		afterEach(() => {
+			fetchMocker.unmockGlobal();
+			server.clear();
+			publicServer.clear();
+		});
+
+		it("should throw an error if message is missing", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			await assert.rejects(instance.post(), {
+				name: "TypeError",
+				message: "Missing message to post.",
+			});
+		});
+
+		it("should throw an error if images are provided", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello, Org Social!";
+			const images = [
+				{
+					data: new Uint8Array([137, 80, 78, 71]),
+					alt: "Test image",
+				},
+			];
+
+			await assert.rejects(instance.post(message, { images }), {
+				name: "Error",
+				message:
+					"Images are not supported in Org Social posts. Consider adding image links in the message text.",
+			});
+		});
+
+		it("should download, update, and upload social.org file", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello, Org Social!";
+
+			// Mock the public URL download
+			publicServer.get(
+				{
+					url: "/testuser/social.org",
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "text/plain; charset=utf-8",
+					},
+					body: SAMPLE_SOCIAL_ORG,
+				},
+			);
+
+			// Mock the upload
+			server.post(
+				{
+					url: "/upload",
+					request: {
+						body: {
+							vfile: SAMPLE_VFILE,
+						},
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						type: "Success",
+						errors: [],
+						data: {
+							message: "File uploaded successfully",
+							"public-url": SAMPLE_PUBLIC_URL,
+						},
+					},
+				},
+			);
+
+			const result = await instance.post(message);
+			assert.strictEqual(result.type, "Success");
+			assert.strictEqual(result.data["public-url"], SAMPLE_PUBLIC_URL);
+		});
+
+		it("should append posts at the end of the file", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Second post!";
+
+			const existingContent = `#+TITLE: Test User
+#+NICK: testuser
+
+* Posts
+**
+:PROPERTIES:
+:ID: 2025-01-01T12:00:00+0100
+:END:
+
+First post content
+`;
+
+			// Mock the public URL download with existing post
+			publicServer.get(
+				{
+					url: "/testuser/social.org",
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "text/plain; charset=utf-8",
+					},
+					body: existingContent,
+				},
+			);
+
+			// Mock the upload
+			server.post(
+				{
+					url: "/upload",
+					request: {
+						body: {
+							vfile: SAMPLE_VFILE,
+						},
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						type: "Success",
+						errors: [],
+						data: {
+							message: "File uploaded successfully",
+							"public-url": SAMPLE_PUBLIC_URL,
+						},
+					},
+				},
+			);
+
+			const result = await instance.post(message);
+			assert.strictEqual(result.type, "Success");
+		});
+
+		it("should create a minimal template if file doesn't exist (404)", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "First post!";
+
+			// Mock 404 response for public URL download
+			publicServer.get(
+				{
+					url: "/testuser/social.org",
+				},
+				{
+					status: 404,
+				},
+			);
+
+			// Mock the upload
+			server.post(
+				{
+					url: "/upload",
+					request: {
+						body: {
+							vfile: SAMPLE_VFILE,
+						},
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						type: "Success",
+						errors: [],
+						data: {
+							message: "File uploaded successfully",
+							"public-url": SAMPLE_PUBLIC_URL,
+						},
+					},
+				},
+			);
+
+			const result = await instance.post(message);
+			assert.strictEqual(result.type, "Success");
+		});
+
+		it("should handle download errors", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello, Org Social!";
+
+			// Mock error response for public URL download
+			publicServer.get(
+				{
+					url: "/testuser/social.org",
+				},
+				{
+					status: 401,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						type: "Error",
+						errors: ["Unauthorized"],
+					},
+				},
+			);
+
+			await assert.rejects(
+				instance.post(message),
+				/Failed to download social\.org/,
+			);
+		});
+
+		it("should handle upload errors", async () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const message = "Hello, Org Social!";
+
+			// Mock successful public URL download
+			publicServer.get(
+				{
+					url: "/testuser/social.org",
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "text/plain; charset=utf-8",
+					},
+					body: SAMPLE_SOCIAL_ORG,
+				},
+			);
+
+			// Mock error response for upload
+			server.post(
+				{
+					url: "/upload",
+					request: {
+						body: {
+							vfile: SAMPLE_VFILE,
+						},
+					},
+				},
+				{
+					status: 400,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						type: "Error",
+						errors: ["Invalid file format"],
+					},
+				},
+			);
+
+			await assert.rejects(
+				instance.post(message),
+				/Failed to upload social\.org/,
+			);
+		});
+	});
+
+	describe("getUrlFromResponse", () => {
+		it("should extract public URL from response", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const response = {
+				type: "Success",
+				errors: [],
+				data: {
+					message: "File uploaded successfully",
+					"public-url": SAMPLE_PUBLIC_URL,
+				},
+			};
+
+			const url = instance.getUrlFromResponse(response);
+			assert.strictEqual(url, SAMPLE_PUBLIC_URL);
+		});
+
+		it("should throw an error if public URL is not in response", () => {
+			const options = {
+				vfile: SAMPLE_VFILE,
+				publicUrl: SAMPLE_PUBLIC_URL,
+			};
+			const instance = new OrgSocialStrategy(options);
+			const response = {
+				type: "Success",
+				errors: [],
+				data: {},
+			};
+
+			assert.throws(
+				() => instance.getUrlFromResponse(response),
+				/Public URL not found in response/,
+			);
+		});
+	});
+});


### PR DESCRIPTION
Implements a new strategy to post messages to Org Social, a decentralized social network based on Org Mode files over HTTP.

Configuration:

- vfile: Virtual file URL with authentication token
- publicUrl: Public URL of the social.org file
- host: Optional Org Social Host instance (defaults to host.org-social.org)

All tests passing