### PR TITLE
feat: Add support for Bluesky card previews

### DIFF
--- a/src/strategies/bluesky.js
+++ b/src/strategies/bluesky.js
@@ -57,6 +57,7 @@ import { validatePostOptions } from "../util/options.js";
  * @property {Object} [record.embed] The embedded content in the post.
  * @property {string} record.embed.$type The type of embedded content.
  * @property {Array<Object>} [record.embed.images] The images to embed.
+ * @property {Object} [record.embed.external] The external link card to embed.
  *
  */
 
@@ -346,6 +347,26 @@ async function postMessage(options, session, message, postOptions) {
 				images,
 			};
 		}
+	} else if (postOptions?.cardPreview) {
+		const { uri, title, description, thumb } = postOptions.cardPreview;
+
+		/** @type {{uri: string, title: string, description: string, thumb?: Object}} */
+		const external = { uri, title, description };
+
+		if (thumb) {
+			const result = await uploadImage(
+				options,
+				session,
+				thumb,
+				postOptions?.signal,
+			);
+			external.thumb = result.blob;
+		}
+
+		body.record.embed = {
+			$type: "app.bsky.embed.external",
+			external,
+		};
 	}
 
 	const response = await fetch(url, {

--- a/src/types.js
+++ b/src/types.js
@@ -18,8 +18,17 @@
  */
 
 /**
+ * @typedef {Object} CardPreview
+ * @property {string} uri The URL of the card.
+ * @property {string} title The title of the card.
+ * @property {string} description The description of the card.
+ * @property {Uint8Array} [thumb] The thumbnail image data.
+ */
+
+/**
  * @typedef {Object} PostOptions
  * @property {ImageEmbedArray} [images] An array of images to include.
+ * @property {CardPreview} [cardPreview] A card preview (external link embed) to include.
  * @property {AbortSignal} [signal] Signal for aborting operations.
  */
 
@@ -33,6 +42,7 @@
  * @property {string} message The message to post.
  * @property {string} strategyId The ID of the strategy to use for posting.
  * @property {ImageEmbedArray} [images] An array of images to include.
+ * @property {CardPreview} [cardPreview] A card preview (external link embed) to include.
  */
 
 /**

--- a/src/util/options.js
+++ b/src/util/options.js
@@ -38,4 +38,26 @@ export function validatePostOptions(options) {
 			}
 		}
 	}
+
+	if (options.images && options.cardPreview) {
+		throw new TypeError("images and cardPreview cannot be used together.");
+	}
+
+	if (options.cardPreview) {
+		if (!options.cardPreview.uri) {
+			throw new TypeError("Card preview must have a uri.");
+		}
+		if (!options.cardPreview.title) {
+			throw new TypeError("Card preview must have a title.");
+		}
+		if (!options.cardPreview.description) {
+			throw new TypeError("Card preview must have a description.");
+		}
+		if (
+			options.cardPreview.thumb &&
+			!(options.cardPreview.thumb instanceof Uint8Array)
+		) {
+			throw new TypeError("Card preview thumb must be a Uint8Array.");
+		}
+	}
 }

--- a/tests/strategies/bluesky.test.js
+++ b/tests/strategies/bluesky.test.js
@@ -715,6 +715,173 @@ describe("BlueskyStrategy", function () {
 		});
 	});
 
+	describe("post with card preview", function () {
+		let strategy;
+
+		beforeEach(function () {
+			strategy = new BlueskyStrategy(options);
+			fetchMocker.mockGlobal();
+		});
+
+		afterEach(() => {
+			fetchMocker.unmockGlobal();
+			server.clear();
+		});
+
+		it("should successfully post a message with a card preview without thumb", async function () {
+			const text = "Check this out!";
+
+			server.post(
+				{
+					url: CREATE_SESSION_URL,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						identifier: options.identifier,
+						password: options.password,
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: CREATE_SESSION_RESPONSE,
+				},
+			);
+
+			server.post(
+				{
+					url: CREATE_RECORD_URL,
+					headers: {
+						"content-type": "application/json",
+						authorization: `Bearer ${CREATE_SESSION_RESPONSE.accessJwt}`,
+					},
+					body: {
+						repo: CREATE_SESSION_RESPONSE.did,
+						collection: "app.bsky.feed.post",
+						record: {
+							$type: "app.bsky.feed.post",
+							text,
+							embed: {
+								$type: "app.bsky.embed.external",
+								external: {
+									uri: "https://example.com/article",
+									title: "Example Article",
+									description: "An interesting article",
+								},
+							},
+						},
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: CREATE_RECORD_RESPONSE,
+				},
+			);
+
+			const response = await strategy.post(text, {
+				cardPreview: {
+					uri: "https://example.com/article",
+					title: "Example Article",
+					description: "An interesting article",
+				},
+			});
+			assert.deepStrictEqual(response, CREATE_RECORD_RESPONSE);
+		});
+
+		it("should successfully post a message with a card preview with thumb", async function () {
+			const text = "Check this out!";
+			const thumbData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+
+			server.post(
+				{
+					url: CREATE_SESSION_URL,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: {
+						identifier: options.identifier,
+						password: options.password,
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: CREATE_SESSION_RESPONSE,
+				},
+			);
+
+			server.post(
+				{
+					url: UPLOAD_BLOB_URL,
+					headers: {
+						"content-type": "*/*",
+						authorization: `Bearer ${CREATE_SESSION_RESPONSE.accessJwt}`,
+					},
+					body: thumbData.buffer,
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: UPLOAD_BLOB_RESPONSE,
+				},
+			);
+
+			server.post(
+				{
+					url: CREATE_RECORD_URL,
+					headers: {
+						"content-type": "application/json",
+						authorization: `Bearer ${CREATE_SESSION_RESPONSE.accessJwt}`,
+					},
+					body: {
+						repo: CREATE_SESSION_RESPONSE.did,
+						collection: "app.bsky.feed.post",
+						record: {
+							$type: "app.bsky.feed.post",
+							text,
+							embed: {
+								$type: "app.bsky.embed.external",
+								external: {
+									uri: "https://example.com/article",
+									title: "Example Article",
+									description: "An interesting article",
+									thumb: UPLOAD_BLOB_RESPONSE.blob,
+								},
+							},
+						},
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: CREATE_RECORD_RESPONSE,
+				},
+			);
+
+			const response = await strategy.post(text, {
+				cardPreview: {
+					uri: "https://example.com/article",
+					title: "Example Article",
+					description: "An interesting article",
+					thumb: thumbData,
+				},
+			});
+			assert.deepStrictEqual(response, CREATE_RECORD_RESPONSE);
+		});
+	});
+
 	describe("getUrlFromResponse", function () {
 		let strategy;
 

--- a/tests/util/options.test.js
+++ b/tests/util/options.test.js
@@ -49,4 +49,77 @@ describe("validatePostOptions()", () => {
 		};
 		assert.doesNotThrow(() => validatePostOptions(options));
 	});
+
+	it("should throw error when cardPreview has no uri", () => {
+		assert.throws(
+			() =>
+				validatePostOptions({
+					cardPreview: { title: "t", description: "d" },
+				}),
+			new TypeError("Card preview must have a uri."),
+		);
+	});
+
+	it("should throw error when cardPreview has no title", () => {
+		assert.throws(
+			() =>
+				validatePostOptions({
+					cardPreview: {
+						uri: "https://example.com",
+						description: "d",
+					},
+				}),
+			new TypeError("Card preview must have a title."),
+		);
+	});
+
+	it("should throw error when cardPreview has no description", () => {
+		assert.throws(
+			() =>
+				validatePostOptions({
+					cardPreview: { uri: "https://example.com", title: "t" },
+				}),
+			new TypeError("Card preview must have a description."),
+		);
+	});
+
+	it("should throw error when cardPreview thumb is not Uint8Array", () => {
+		assert.throws(
+			() =>
+				validatePostOptions({
+					cardPreview: {
+						uri: "https://example.com",
+						title: "t",
+						description: "d",
+						thumb: "not bytes",
+					},
+				}),
+			new TypeError("Card preview thumb must be a Uint8Array."),
+		);
+	});
+
+	it("should not throw error when cardPreview is valid", () => {
+		assert.doesNotThrow(() =>
+			validatePostOptions({
+				cardPreview: {
+					uri: "https://example.com",
+					title: "Example",
+					description: "An example",
+				},
+			}),
+		);
+	});
+
+	it("should not throw error when cardPreview has valid thumb", () => {
+		assert.doesNotThrow(() =>
+			validatePostOptions({
+				cardPreview: {
+					uri: "https://example.com",
+					title: "Example",
+					description: "An example",
+					thumb: new Uint8Array(),
+				},
+			}),
+		);
+	});
 });


### PR DESCRIPTION
I noticed that when my post has a link, Bluesky doesn't automatically add an embed card. For example, compare these two posts:

- https://hachyderm.io/@ohmjs/116058219131470979 (with embed card)
- https://bsky.app/profile/ohmjs.org/post/3meoajqs6sv2c (no embed card)

This PR adds support for Bluesky embed cards, via `embed` with `$type: "app.bsky.embed.external"` as described [here](https://kulpinski.dev/posts/embed-card-links-on-bluesky/).

Here's a test post that was generated via the code in this PR: https://bsky.app/profile/ohmjs.org/post/3meog7agbhw25