### PR TITLE
fix(devto): support public image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Usage: crosspost [options] ["Message to post."]
 --mcp           Start MCP server.
 --file          The file to read the message from.
 --image         The image file to upload with the message.
+--image-url     A public URL to include with the message.
 --image-alt     Alt text for the image (default: filename).
 --help, -h      Show this message.
 --version, -v   Show version number.
@@ -201,6 +202,9 @@ npx @humanwhocodes/crosspost -t -m -b "Check out this beach!"
 
 # Post a message with an image to multiple services
 npx @humanwhocodes/crosspost -t -m -b --image ./photo.jpg --image-alt "A beautiful sunset" "Check out this beach!"
+
+# Post a Dev.to article with a public image URL
+npx @humanwhocodes/crosspost --devto --image-url https://example.com/photo.jpg --image-alt "A beautiful sunset" "Check out this beach!"
 ```
 
 This posts the message `"Hello world!"` to Twitter, Mastodon, and Bluesky with an attached image. You can choose to post to any combination by specifying the appropriate command line options.

--- a/src/bin.js
+++ b/src/bin.js
@@ -69,6 +69,7 @@ const options = {
 	mcp: { type: booleanType },
 	file: { type: stringType },
 	image: { type: stringType },
+	"image-url": { type: stringType },
 	"image-alt": { type: stringType },
 	help: { type: booleanType, short: "h" },
 	version: { type: booleanType, short: "v" },
@@ -120,6 +121,7 @@ if (
 	console.log("--mcp		Start MCP server.");
 	console.log("--file		The file to read the message from.");
 	console.log("--image		The image file to upload with the message.");
+	console.log("--image-url	A public URL to include with the message.");
 	console.log("--image-alt	Alt text for the image (default: filename).");
 	console.log("--help, -h	Show this message.");
 	console.log("--version, -v	Show version number.");
@@ -273,6 +275,16 @@ if (flags.mcp) {
 		"MCP server started. You can now send messages to it via stdin.",
 	);
 } else {
+	const imageUrl = flags["image-url"];
+	const isOnlyDevto = strategies.length === 1 && strategies[0].id === "devto";
+
+	if (imageUrl && !flags.image && !isOnlyDevto) {
+		console.error(
+			"Error: --image-url without --image can only be used with --devto.",
+		);
+		process.exit(1);
+	}
+
 	// if an image is specified, read it and add to options
 	if (flags.image) {
 		try {
@@ -282,6 +294,7 @@ if (flags.mcp) {
 			postOptions.images = [
 				{
 					data: new Uint8Array(imageData),
+					url: imageUrl,
 					alt: flags["image-alt"] || basename,
 				},
 			];
@@ -290,6 +303,16 @@ if (flags.mcp) {
 			console.error(`Error reading image file: ${fileError.message}`);
 			process.exit(1);
 		}
+	} else if (imageUrl) {
+		const basename = imageUrl.split(/[\\/]/).pop() || imageUrl;
+
+		postOptions.images = [
+			{
+				data: new Uint8Array(),
+				url: imageUrl,
+				alt: flags["image-alt"] || basename,
+			},
+		];
 	}
 
 	/*

--- a/src/strategies/devto.js
+++ b/src/strategies/devto.js
@@ -3,16 +3,10 @@
  * @author Nicholas C. Zakas
  */
 
-/* global fetch, Buffer */
+/* global fetch */
 
 //-----------------------------------------------------------------------------
 // Imports
-//-----------------------------------------------------------------------------
-
-import { getImageMimeType } from "../util/images.js";
-
-//-----------------------------------------------------------------------------
-// Type Definitions
 //-----------------------------------------------------------------------------
 
 /**
@@ -95,11 +89,16 @@ async function postArticle(apiKey, content, postOptions) {
 
 	// if there are images, append them to the content
 	if (postOptions?.images?.length) {
-		articleContent += "\n\n";
+		const articleImages = [];
+
 		for (const image of postOptions.images) {
-			const base64 = Buffer.from(image.data).toString("base64");
-			const mimeType = getImageMimeType(image.data);
-			articleContent += `![${image.alt || ""}](data:${mimeType};base64,${base64})\n\n`;
+			if (image.url) {
+				articleImages.push(`![${image.alt || ""}](${image.url})`);
+			}
+		}
+
+		if (articleImages.length) {
+			articleContent += `\n\n${articleImages.join("\n\n")}\n\n`;
 		}
 	}
 

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,7 @@
  * @typedef {Object} ImageEmbed
  * @property {string} [alt] The alt text for the image.
  * @property {Uint8Array} data The image data.
+ * @property {string} [url] A public URL for the image.
  */
 
 /**

--- a/tests/bin.test.js
+++ b/tests/bin.test.js
@@ -120,4 +120,61 @@ describe("bin", function () {
 			});
 		});
 	});
+
+	describe("image-url flag", function () {
+		it("should display image-url help", done => {
+			const child = fork(builtExecutablePath, ["--help"], {
+				stdio: "pipe",
+			});
+
+			let output = "";
+
+			child.stdout.on("data", data => {
+				output += data.toString();
+			});
+
+			child.on("exit", code => {
+				assert.strictEqual(code, 1);
+				assert.match(output, /--image-url\s+A public URL/);
+				done();
+			});
+		});
+
+		it("should reject image-url without image for multiple strategies", done => {
+			const child = fork(
+				builtExecutablePath,
+				[
+					"--devto",
+					"--mastodon",
+					"--image-url",
+					"https://example.com/image.png",
+					"Hello world",
+				],
+				{
+					env: {
+						...process.env,
+						DEVTO_API_KEY: "devto-key",
+						MASTODON_ACCESS_TOKEN: "mastodon-token",
+						MASTODON_HOST: "mastodon.social",
+					},
+					stdio: "pipe",
+				},
+			);
+
+			let errorOutput = "";
+
+			child.stderr.on("data", data => {
+				errorOutput += data.toString();
+			});
+
+			child.on("exit", code => {
+				assert.strictEqual(code, 1);
+				assert.match(
+					errorOutput,
+					/--image-url without --image can only be used with --devto/,
+				);
+				done();
+			});
+		});
+	});
 });

--- a/tests/strategies/devto.test.js
+++ b/tests/strategies/devto.test.js
@@ -135,13 +135,6 @@ describe("DevtoStrategy", () => {
 		it("should successfully post an article with images", async () => {
 			const content = "Hello World\n\nThis is a test post.";
 			const imageData = new Uint8Array([137, 80, 78, 71]); // Example PNG header
-			const base64Data = "iVBORw=="; // Example base64 of the image data
-
-			const expectedContent =
-				content +
-				"\n\n" +
-				`![Test image](data:image/png;base64,${base64Data})\n\n` +
-				`![Another image](data:image/png;base64,${base64Data})\n\n`;
 
 			server.post(
 				{
@@ -153,7 +146,7 @@ describe("DevtoStrategy", () => {
 					body: {
 						article: {
 							title: "Hello World",
-							body_markdown: expectedContent,
+							body_markdown: content,
 							published: true,
 						},
 					},
@@ -183,15 +176,13 @@ describe("DevtoStrategy", () => {
 			assert.deepStrictEqual(response, CREATE_ARTICLE_RESPONSE);
 		});
 
-		it("should successfully post an article with JPEG images", async () => {
+		it("should successfully post an article with image URLs", async () => {
 			const content = "Hello World\n\nThis is a test post.";
-			const imageData = new Uint8Array([0xff, 0xd8, 0xff]); // JPEG header
-			const base64Data = "/9j/"; // Example base64 of the image data
+			const imageData = new Uint8Array([137, 80, 78, 71]); // Example PNG header
+			const imageUrl = "https://example.com/image.png";
 
 			const expectedContent =
-				content +
-				"\n\n" +
-				`![Test image](data:image/jpeg;base64,${base64Data})\n\n`;
+				content + "\n\n" + `![Test image](${imageUrl})\n\n`;
 
 			server.post(
 				{
@@ -222,6 +213,7 @@ describe("DevtoStrategy", () => {
 					{
 						alt: "Test image",
 						data: imageData,
+						url: imageUrl,
 					},
 				],
 			});
@@ -229,15 +221,9 @@ describe("DevtoStrategy", () => {
 			assert.deepStrictEqual(response, CREATE_ARTICLE_RESPONSE);
 		});
 
-		it("should successfully post an article with images without alt text", async () => {
+		it("should successfully post an article with JPEG images", async () => {
 			const content = "Hello World\n\nThis is a test post.";
-			const imageData = new Uint8Array([137, 80, 78, 71]); // Example PNG header
-			const base64Data = "iVBORw=="; // Example base64 of the image data
-
-			const expectedContent =
-				content +
-				"\n\n" +
-				`![](data:image/png;base64,${base64Data})\n\n`;
+			const imageData = new Uint8Array([0xff, 0xd8, 0xff]); // JPEG header
 
 			server.post(
 				{
@@ -249,7 +235,47 @@ describe("DevtoStrategy", () => {
 					body: {
 						article: {
 							title: "Hello World",
-							body_markdown: expectedContent,
+							body_markdown: content,
+							published: true,
+						},
+					},
+				},
+				{
+					status: 201,
+					headers: {
+						"content-type": "application/json",
+					},
+					body: CREATE_ARTICLE_RESPONSE,
+				},
+			);
+
+			const response = await strategy.post(content, {
+				images: [
+					{
+						alt: "Test image",
+						data: imageData,
+					},
+				],
+			});
+
+			assert.deepStrictEqual(response, CREATE_ARTICLE_RESPONSE);
+		});
+
+		it("should successfully post an article with images without alt text", async () => {
+			const content = "Hello World\n\nThis is a test post.";
+			const imageData = new Uint8Array([137, 80, 78, 71]); // Example PNG header
+
+			server.post(
+				{
+					url: "/api/articles",
+					headers: {
+						"content-type": "application/json",
+						"api-key": API_KEY,
+					},
+					body: {
+						article: {
+							title: "Hello World",
+							body_markdown: content,
 							published: true,
 						},
 					},


### PR DESCRIPTION

Fixes #170.

## Summary

- Adds a `--image-url` CLI option for public image URLs.
- Uses image URLs when composing Dev.to article Markdown instead of embedding base64 data URIs.
- Keeps existing local `--image` behavior for platforms that upload binary image data.
- Allows URL-only images only for Dev.to, because the other strategies still require local image data.

## Verification

- `npm run build`
- `npm run lint`
- `npm test`
- `git diff --check`

## Notes

Dev.to appears to reject or sanitize base64 data URI images in article Markdown, while regular public image URLs render as expected. This keeps the fix scoped to Dev.to and avoids changing image validation for the other strategies.
